### PR TITLE
add go-live release guardrails and readiness checks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,37 @@
+# Required: primary application database connection.
+DATABASE_URL=postgresql://user:password@host:5432/elite_crm
+
+# Required: protects internal runner endpoints.
+INTERNAL_RUNNER_KEY=replace_with_secure_random_key
+
+# Required: Supabase project URL for object storage.
+SUPABASE_URL=https://your-project-ref.supabase.co
+# Required: Supabase service role key used by server-side uploads/deletes.
+SUPABASE_SERVICE_ROLE_KEY=replace_with_supabase_service_role_key
+# Required: bucket name used for carrier documents.
+SUPABASE_STORAGE_BUCKET=carrier-documents
+
+# Required: org id used by scheduler runner requests.
+RUNNER_ORGANIZATION_ID=replace_with_org_id
+# Required: public app URL used by scripts/run-internal-runners.mjs.
+APP_BASE_URL=https://your-app-domain.com
+
+# Optional: provider credentials for AI routes (configure the one(s) you use).
+OPENAI_API_KEY=
+ANTHROPIC_API_KEY=
+GOOGLE_API_KEY=
+
+# Optional: enables Linear sync route integration.
+LINEAR_API_KEY=
+
+# Optional: scraping provider key for ScrapingBee proxy mode.
+SCRAPINGBEE_API_KEY=
+# Optional: custom proxy URL template for scraper ({url} placeholder required).
+SCRAPER_PROXY_URL_TEMPLATE=
+# Optional: Firecrawl scraping API key.
+FIRECRAWL_API_KEY=
+
+# Optional: trust proxy headers when not running on Vercel.
+TRUST_PROXY=0
+# Optional: local/dev fallback org context.
+DEV_DEFAULT_ORG_ID=

--- a/ELITE_TEST_CHECKLIST.md
+++ b/ELITE_TEST_CHECKLIST.md
@@ -8,6 +8,10 @@ Use this checklist for pre-release smoke testing of elite CRM flows.
 - [x] `npm run build` passed (multiple runs during P0 go-live execution)
 - [x] `npm run db:generate` passed
 - [x] `npm run db:push` passed for local schema sync
+- [x] Automated API smoke sweep completed (non-interactive)
+  - 29 endpoint/action checks executed
+  - 28 passed
+  - 1 failed (`POST /api/ai` `generate-content`) due external LLM runtime/provider availability
 - [ ] Manual UI smoke flow items still require browser run-through in target environment
 
 ## 1) Lead Scraping

--- a/GO_LIVE_TOMORROW.md
+++ b/GO_LIVE_TOMORROW.md
@@ -1,0 +1,111 @@
+# Go-Live Tomorrow Checklist
+
+Run this list in order. Each step includes a quick verification before moving on.
+
+## 1) Configure environment variables
+
+Set production variables from `.env.example` in your hosting provider dashboard.
+
+Required minimum:
+- `DATABASE_URL`
+- `INTERNAL_RUNNER_KEY`
+- `SUPABASE_URL`
+- `SUPABASE_SERVICE_ROLE_KEY`
+- `SUPABASE_STORAGE_BUCKET`
+- `RUNNER_ORGANIZATION_ID`
+- `APP_BASE_URL`
+- AI provider key(s) used by your deployment
+
+Optional:
+- `LINEAR_API_KEY`
+- `SCRAPINGBEE_API_KEY`
+- `SCRAPER_PROXY_URL_TEMPLATE`
+- `FIRECRAWL_API_KEY`
+- `TRUST_PROXY=1` (if behind a trusted reverse proxy and not on Vercel)
+
+Verify:
+- Confirm no `.env` or secret file is committed to git.
+
+## 2) Prepare production database
+
+1. Create a production Postgres instance.
+2. Set `DATABASE_URL` in the host.
+3. Run:
+   - `npm run db:generate`
+   - migration deploy step for your environment (for Prisma, typically `prisma migrate deploy` in CI/CD)
+
+Verify:
+- `GET /api/ready` returns 200 and reports database `ok`.
+
+## 3) Configure Supabase object storage
+
+1. Create the bucket referenced by `SUPABASE_STORAGE_BUCKET`.
+2. Ensure server-side credentials (`SUPABASE_SERVICE_ROLE_KEY`) are valid.
+3. Confirm bucket policies allow server-side upload/delete operations.
+
+Verify:
+- Upload a carrier document in the app and confirm object exists in the bucket.
+
+## 4) Schedule automation runner
+
+Create a recurring job that runs:
+- `npm run runner:tick`
+
+Required runner env:
+- `APP_BASE_URL`
+- `INTERNAL_RUNNER_KEY`
+- `RUNNER_ORGANIZATION_ID`
+
+Recommended cadence:
+- Every 5-15 minutes (adjust by lead/content volume).
+
+Verify:
+- Trigger the runner once manually and confirm successful calls to:
+  - `POST /api/sequences/run`
+  - `POST /api/content/publish`
+
+## 5) Deploy application
+
+Deploy using your normal CI/CD path (for example push to `main` for Vercel).
+
+Verify:
+- `GET /api/health` returns 200.
+- `GET /api/ready` returns 200 after database is online.
+
+## 6) Execute manual smoke tests
+
+Run sections 1-7 in `ELITE_TEST_CHECKLIST.md`:
+- lead scraping
+- social content generation and publishing
+- follow-up automation
+- AI scoring/feedback/my-day
+- carrier library
+- carrier AI playbook + save to timeline
+- runner security behavior
+
+Verify:
+- Each section passes with expected status transitions and activity records.
+
+## 7) Verify runner endpoint security
+
+With `INTERNAL_RUNNER_KEY` set:
+1. Call runner endpoints without `x-internal-runner-key`.
+2. Expect `401`.
+3. Call again with valid `x-internal-runner-key`.
+4. Expect success.
+
+Endpoints:
+- `POST /api/content/publish`
+- `POST /api/sequences/run`
+
+Verify:
+- Scheduler is configured with the key and correct org id.
+
+## 8) Final release gate
+
+Run:
+- `npm run release-gate`
+
+Verify:
+- Lint, build, Prisma generate, and tests all pass.
+- No secrets are staged or committed.

--- a/PROJECT_SUMMARY.md
+++ b/PROJECT_SUMMARY.md
@@ -61,6 +61,8 @@ Elite CRM is a multi-tenant, AI-first CRM platform for life and health insurance
 
 - Core feature architecture is in place across API, DB, and UI.
 - Lint and production build passed in this session.
+- Automated non-interactive API smoke sweep passed for 28/29 tested endpoint actions.
+- Remaining automated failure is isolated to AI generation route provider/runtime availability (`POST /api/ai` action: `generate-content`).
 
 ### Must complete before production launch
 

--- a/cursor_sessionhandoff.md
+++ b/cursor_sessionhandoff.md
@@ -104,6 +104,10 @@ The following commands were run successfully after each major change set:
 - `npm run db:generate` ✅
 - `npm run db:push` ✅
 - `npm run runner:tick` wiring added (requires production env vars/secrets)
+- Automated non-interactive API smoke sweep ✅
+  - 29 endpoint/action checks run against local server
+  - 28 passed
+  - 1 failed due external AI provider/runtime dependency on `POST /api/ai` (`generate-content`)
 
 Build output confirms these important routes are active:
 
@@ -189,6 +193,7 @@ Build output confirms these important routes are active:
    - generate playbook -> verify scripts + citations
    - save playbook -> verify activity timeline record
    - run `npm run runner:tick` -> confirm sequence/content runners succeed
+   - verify `POST /api/ai` generation actions with production AI credentials/runtime
 
 ---
 

--- a/docs/plans/2026-03-12-overnight-go-live-prep.md
+++ b/docs/plans/2026-03-12-overnight-go-live-prep.md
@@ -1,0 +1,12 @@
+# Overnight Go-Live Prep
+
+Source plan reference: `.cursor/plans/overnight_go-live_prep_70804502.plan.md`
+
+This file mirrors the approved implementation scope for overnight execution:
+- Add `GET /api/health`
+- Add `GET /api/ready`
+- Add `.env.example`
+- Add `scripts/release-gate.mjs` and npm script
+- Run tests/release gate and fix regressions
+- Create `GO_LIVE_TOMORROW.md`
+- Optional: add shared API error response helper

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "NODE_ENV=production bun .next/standalone/server.js 2>&1 | tee server.log",
     "test": "vitest run",
     "lint": "eslint .",
+    "release-gate": "node scripts/release-gate.mjs",
     "db:push": "prisma db push",
     "db:generate": "prisma generate",
     "db:migrate": "prisma migrate dev",

--- a/scripts/release-gate.mjs
+++ b/scripts/release-gate.mjs
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process'
+
+const checks = [
+  { label: 'Lint', command: 'npm', args: ['run', 'lint'] },
+  { label: 'Build', command: 'npm', args: ['run', 'build'] },
+  { label: 'Prisma generate', command: 'npm', args: ['run', 'db:generate'] },
+  { label: 'Tests', command: 'npm', args: ['run', 'test'] },
+]
+
+for (const check of checks) {
+  console.log(`\n=== ${check.label}: ${check.command} ${check.args.join(' ')} ===`)
+  const result = spawnSync(check.command, check.args, { stdio: 'inherit' })
+  if (result.status !== 0) {
+    console.error(`\nRelease gate failed at: ${check.label}`)
+    process.exit(result.status ?? 1)
+  }
+}
+
+console.log('\nRelease gate passed.')

--- a/src/app/api/ai/carrier-playbook/save/route.ts
+++ b/src/app/api/ai/carrier-playbook/save/route.ts
@@ -5,6 +5,7 @@ import { getOrgContext } from '@/lib/request-context'
 import { z } from 'zod'
 import { parseJsonBody } from '@/lib/validation'
 import { enforceRateLimit } from '@/lib/rate-limit'
+import { apiError } from '@/lib/api-error'
 
 const savePlaybookSchema = z.object({
   leadId: z.string().min(1),
@@ -17,7 +18,7 @@ export async function POST(request: NextRequest) {
     const limited = enforceRateLimit(request, { key: 'carrier-playbook-save', limit: 40, windowMs: 60_000 })
     if (limited) return limited
     const context = await getOrgContext(request)
-    if (!context) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    if (!context) return apiError('Unauthorized', 401, 'unauthorized')
     const parsed = await parseJsonBody(request, savePlaybookSchema)
     if (!parsed.success) return parsed.response
     const { leadId, playbook, source = 'manual' } = parsed.data
@@ -25,7 +26,7 @@ export async function POST(request: NextRequest) {
     const lead = await db.lead.findFirst({
       where: { id: leadId, organizationId: context.organizationId },
     })
-    if (!lead) return NextResponse.json({ error: 'Lead not found' }, { status: 404 })
+    if (!lead) return apiError('Lead not found', 404, 'lead_not_found')
 
     const recommendedCarrier = String(
       ((playbook.recommendedCarrier as Record<string, unknown> | undefined)?.name as string) || 'Unknown carrier'
@@ -49,6 +50,6 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ activity: savedActivity })
   } catch (error) {
     console.error('Save playbook error:', error)
-    return NextResponse.json({ error: 'Failed to save playbook' }, { status: 500 })
+    return apiError('Failed to save playbook', 500, 'save_playbook_failed')
   }
 }

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server'
+
+export async function GET() {
+  return NextResponse.json({
+    ok: true,
+    timestamp: new Date().toISOString(),
+  })
+}

--- a/src/app/api/ready/route.ts
+++ b/src/app/api/ready/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server'
+import { db } from '@/lib/db'
+
+export async function GET() {
+  const databaseUrl = process.env.DATABASE_URL?.trim()
+  if (!databaseUrl) {
+    return NextResponse.json({
+      ok: true,
+      ready: true,
+      database: 'skipped_no_database_url',
+      timestamp: new Date().toISOString(),
+    })
+  }
+
+  try {
+    await db.$queryRaw`SELECT 1`
+    return NextResponse.json({
+      ok: true,
+      ready: true,
+      database: 'ok',
+      timestamp: new Date().toISOString(),
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown readiness error'
+    return NextResponse.json(
+      {
+        ok: false,
+        ready: false,
+        database: 'error',
+        error: message,
+        timestamp: new Date().toISOString(),
+      },
+      { status: 503 }
+    )
+  }
+}

--- a/src/lib/api-error.ts
+++ b/src/lib/api-error.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server'
+
+export function apiError(message: string, status: number, code?: string) {
+  return NextResponse.json(
+    {
+      error: message,
+      ...(code ? { code } : {}),
+    },
+    { status }
+  )
+}

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -13,10 +13,32 @@ type RateEntry = {
 
 const buckets = new Map<string, RateEntry>()
 
+/** Whether forwarded headers are set by a trusted proxy (e.g. Vercel), not by the client. */
+function isTrustedProxy(): boolean {
+  return process.env.VERCEL === '1' || process.env.TRUST_PROXY === '1'
+}
+
+/** Basic validation: allow IPv4, IPv6, or localhost. Reject anything that looks like injection. */
+function isValidIpCandidate(value: string): boolean {
+  const trimmed = value.trim()
+  if (!trimmed || trimmed.length > 45) return false
+  // IPv4, IPv6, or hostnames like "localhost" / "::1"
+  return /^[\d.:a-fA-F]+$/.test(trimmed) || trimmed === 'localhost'
+}
+
 function getClientIp(request: NextRequest): string {
+  if (!isTrustedProxy()) {
+    // Do not use client-controlled headers; one bucket for all unidentifiable clients.
+    return 'anonymous'
+  }
   const forwardedFor = request.headers.get('x-forwarded-for')
-  if (forwardedFor) return forwardedFor.split(',')[0].trim()
-  return request.headers.get('x-real-ip') || 'unknown'
+  if (forwardedFor) {
+    const first = forwardedFor.split(',')[0].trim()
+    if (isValidIpCandidate(first)) return first
+  }
+  const realIp = request.headers.get('x-real-ip')
+  if (realIp && isValidIpCandidate(realIp.trim())) return realIp.trim()
+  return 'unknown'
 }
 
 function compactExpiredEntries(now: number) {

--- a/worklog.md
+++ b/worklog.md
@@ -195,3 +195,37 @@
 - Batch 3/4:
   - `npm run lint` ✅
   - `npm run build` ✅
+
+## 2026-03-13 - Full Non-Interactive Feature Sweep
+
+### Scope
+
+- Ran full project-level non-interactive validation and endpoint/action smoke tests without manual UI input.
+- Included API create/update/delete flows, security checks, runner authorization checks, and upload/carrier document workflows.
+
+### Verification commands
+
+- `npm run lint` ✅
+- `npm run build` ✅
+- `npm test` ✅ (2 test files, 5 tests)
+- `npm run db:push` ✅
+- targeted endpoint checks via local server + scripted fetch suite ✅
+
+### API smoke results
+
+- 29 endpoint/action checks executed.
+- 28 passed.
+- 1 failed:
+  - `POST /api/ai` with `action: generate-content`
+  - failure reason: AI provider/runtime availability (`LLM.chat` undefined in current runtime context)
+
+### Notable validated behaviors
+
+- Runner security hardening verified:
+  - `POST /api/content/publish` returns `401` without `x-internal-runner-key`
+  - `POST /api/sequences/run` returns `401` without `x-internal-runner-key`
+  - both succeed when key is provided
+- CRUD/mutation flows validated for:
+  - leads, activities, content, sequences/enrollment, pipeline, scrape jobs, bookings, SMS logging
+  - carrier CRUD and document upload/delete path
+  - playbook generate/save path (fallback path exercised successfully)


### PR DESCRIPTION
Add health/readiness endpoints, a release-gate runner, and shared API error responses to tighten launch operations. Document full non-interactive validation results and tomorrow go-live execution steps so deployment can proceed with clear verification checkpoints.

Made-with: Cursor

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds health/readiness endpoints, a `release-gate` script, and a shared API error helper to enforce go-live guardrails. Includes `.env.example`, go-live docs, and rate-limit hardening; non-interactive API sweep passed 28/29 (AI generation depends on provider).

- New Features
  - `GET /api/health` basic health check.
  - `GET /api/ready` with DB probe; returns 503 on failure.
  - `scripts/release-gate.mjs` + `npm run release-gate` (lint, build, Prisma generate, tests; fails fast).
  - `src/lib/api-error.ts` for consistent JSON errors; used in carrier playbook save route.
  - Rate limit now trusts proxy headers only on `VERCEL` or `TRUST_PROXY=1` and validates IPs to prevent spoofing.

- Migration
  - Configure prod env from `.env.example` (DB, `INTERNAL_RUNNER_KEY`, Supabase, runner org/URL, AI key(s)).
  - Schedule `npm run runner:tick` with `APP_BASE_URL`, `INTERNAL_RUNNER_KEY`, `RUNNER_ORGANIZATION_ID`.
  - Verify `GET /api/health` and `GET /api/ready` return 200; runner endpoints require `x-internal-runner-key`.
  - Run `npm run release-gate` before launch and follow `GO_LIVE_TOMORROW.md`.

<sup>Written for commit fe4d6dc318eaadfa2c602fbb2213c82947348d99. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

