### PR TITLE
Codex-generated pull request

### DIFF
--- a/src/app/api/automations/route.ts
+++ b/src/app/api/automations/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from "next/server"
+
+type Automation = {
+  id: string
+  name: string
+  trigger: string
+  actions: string
+  createdAt: string
+}
+
+const automationsStore: Automation[] = []
+
+export async function GET() {
+  return NextResponse.json({ automations: automationsStore })
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = (await request.json()) as Partial<Automation>
+    const name = body.name?.trim()
+    const trigger = body.trigger?.trim()
+    const actions = body.actions?.trim()
+
+    if (!name || !trigger || !actions) {
+      return NextResponse.json(
+        { error: "name, trigger, and actions are required." },
+        { status: 400 },
+      )
+    }
+
+    const automation: Automation = {
+      id: crypto.randomUUID(),
+      name,
+      trigger,
+      actions,
+      createdAt: new Date().toISOString(),
+    }
+    automationsStore.unshift(automation)
+
+    return NextResponse.json({ automation }, { status: 201 })
+  } catch {
+    return NextResponse.json({ error: "Invalid request payload." }, { status: 400 })
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -43,6 +43,7 @@ import { ChartContainer, ChartTooltip, ChartTooltipContent, type ChartConfig } f
 import { AreaChart, Area, XAxis, YAxis, CartesianGrid, ResponsiveContainer, BarChart, Bar, PieChart as RechartsPieChart, Pie, Cell, LineChart, Line } from "recharts"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
 import { CommandPalette, useCommandPalette } from "@/components/command-palette"
+import { AutomationView } from "@/components/automation/automation-view"
 import { triggerWinCelebration, triggerSmallCelebration } from "@/lib/celebrations"
 import { toast } from "@/hooks/use-toast"
 
@@ -2215,45 +2216,6 @@ function CreateLinearIssueDialog({
 }
 
 // Placeholder views for other sections
-function AutomationView() {
-  return (
-    <div className="p-6 space-y-6 bg-[#FDFBF7] min-h-screen">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold text-black">AI Automation</h1>
-          <p className="text-gray-500">Automate your workflows with intelligent triggers</p>
-        </div>
-        <Button className="btn-gold gap-2">
-          <Plus className="w-4 h-4" />
-          Create Automation
-        </Button>
-      </div>
-      
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        {[
-          { title: "Active Automations", value: 12, icon: Zap },
-          { title: "Runs This Month", value: 1234, icon: Activity },
-          { title: "AI Accuracy", value: "94%", icon: Brain },
-        ].map((stat) => (
-          <Card key={stat.title} className="bg-white border-[#E2DDD4] shadow-sm">
-            <CardContent className="p-4">
-              <div className="flex items-center gap-3">
-                <div className="w-10 h-10 rounded-lg bg-[#3B8595]/20 flex items-center justify-center">
-                  <stat.icon className="w-5 h-5 text-[#3B8595]" />
-                </div>
-                <div>
-                  <p className="text-2xl font-bold text-black">{stat.value}</p>
-                  <p className="text-sm text-gray-500">{stat.title}</p>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-        ))}
-      </div>
-    </div>
-  )
-}
-
 function SocialMediaView() {
   type QueueItem = {
     id: string

--- a/src/components/automation/automation-view.test.ts
+++ b/src/components/automation/automation-view.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { openCreateAutomationDialog, submitAutomation } from "@/components/automation/automation-view"
+
+describe("AutomationView helpers", () => {
+  it("opens create automation dialog from button click handler", () => {
+    const setOpen = vi.fn()
+
+    openCreateAutomationDialog(setOpen)
+
+    expect(setOpen).toHaveBeenCalledWith(true)
+  })
+
+  it("submits automation and fires success callback", async () => {
+    const fetchAutomations = vi.fn().mockResolvedValue(undefined)
+    const onCreateSuccess = vi.fn()
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ automation: { id: "a1" } }),
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    await submitAutomation({
+      name: "Welcome Flow",
+      trigger: "new lead",
+      actions: "send email",
+      fetchAutomations,
+      onCreateSuccess,
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/automations", expect.objectContaining({ method: "POST" }))
+    expect(fetchAutomations).toHaveBeenCalledTimes(1)
+    expect(onCreateSuccess).toHaveBeenCalledTimes(1)
+
+    vi.unstubAllGlobals()
+  })
+})

--- a/src/components/automation/automation-view.tsx
+++ b/src/components/automation/automation-view.tsx
@@ -1,0 +1,215 @@
+"use client"
+
+import { useCallback, useEffect, useState, type FormEvent } from "react"
+import { Activity, Brain, Plus, Zap } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { toast } from "@/hooks/use-toast"
+
+type Automation = {
+  id: string
+  name: string
+  trigger: string
+  actions: string
+}
+
+type AutomationViewProps = {
+  onCreateSuccess?: () => void
+}
+
+type SubmitAutomationParams = {
+  name: string
+  trigger: string
+  actions: string
+  fetchAutomations: () => Promise<void>
+  onCreateSuccess?: () => void
+}
+
+export function openCreateAutomationDialog(setShowCreateAutomationDialog: (open: boolean) => void) {
+  setShowCreateAutomationDialog(true)
+}
+
+export async function submitAutomation({ name, trigger, actions, fetchAutomations, onCreateSuccess }: SubmitAutomationParams) {
+  const response = await fetch("/api/automations", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name: name.trim(), trigger: trigger.trim(), actions: actions.trim() }),
+  })
+  const payload = await response.json()
+  if (!response.ok) {
+    throw new Error(payload?.error ?? "Failed to create automation")
+  }
+
+  await fetchAutomations()
+  onCreateSuccess?.()
+}
+
+export function AutomationView({ onCreateSuccess }: AutomationViewProps) {
+  const [automations, setAutomations] = useState<Automation[]>([])
+  const [loadingAutomations, setLoadingAutomations] = useState(true)
+  const [showCreateAutomationDialog, setShowCreateAutomationDialog] = useState(false)
+  const [name, setName] = useState("")
+  const [trigger, setTrigger] = useState("")
+  const [actions, setActions] = useState("")
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const fetchAutomations = useCallback(async () => {
+    setLoadingAutomations(true)
+    try {
+      const response = await fetch("/api/automations")
+      const payload = await response.json()
+      if (!response.ok) {
+        throw new Error(payload?.error ?? "Failed to load automations")
+      }
+      setAutomations(Array.isArray(payload.automations) ? payload.automations : [])
+    } catch (error) {
+      toast({
+        title: "Unable to load automations",
+        description: error instanceof Error ? error.message : "Unknown error",
+        variant: "destructive",
+      })
+      setAutomations([])
+    } finally {
+      setLoadingAutomations(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void fetchAutomations()
+  }, [fetchAutomations])
+
+  const resetForm = () => {
+    setName("")
+    setTrigger("")
+    setActions("")
+  }
+
+  const handleCreateAutomation = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (isSubmitting) return
+
+    if (!name.trim() || !trigger.trim() || !actions.trim()) {
+      toast({
+        title: "Missing required fields",
+        description: "Name, trigger, and actions are required.",
+        variant: "destructive",
+      })
+      return
+    }
+
+    setIsSubmitting(true)
+    try {
+      await submitAutomation({ name, trigger, actions, fetchAutomations, onCreateSuccess })
+      toast({
+        title: "Automation created",
+        description: "Your automation is now active.",
+      })
+      setShowCreateAutomationDialog(false)
+      resetForm()
+    } catch (error) {
+      toast({
+        title: "Failed to create automation",
+        description: error instanceof Error ? error.message : "Unknown error",
+        variant: "destructive",
+      })
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="p-6 space-y-6 bg-[#FDFBF7] min-h-screen">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-black">AI Automation</h1>
+          <p className="text-gray-500">Automate your workflows with intelligent triggers</p>
+        </div>
+        <Button className="btn-gold gap-2" onClick={() => openCreateAutomationDialog(setShowCreateAutomationDialog)}>
+          <Plus className="w-4 h-4" />
+          Create Automation
+        </Button>
+      </div>
+
+      <Dialog open={showCreateAutomationDialog} onOpenChange={setShowCreateAutomationDialog}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Create automation</DialogTitle>
+            <DialogDescription>Set a name, trigger, and actions to start an automation workflow.</DialogDescription>
+          </DialogHeader>
+          <form onSubmit={handleCreateAutomation} className="space-y-4" data-testid="create-automation-form">
+            <fieldset disabled={isSubmitting} className="space-y-4 disabled:opacity-70">
+              <div className="space-y-2">
+                <Label htmlFor="automation-name">Name</Label>
+                <Input id="automation-name" value={name} onChange={(event) => setName(event.target.value)} required />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="automation-trigger">Trigger</Label>
+                <Input id="automation-trigger" value={trigger} onChange={(event) => setTrigger(event.target.value)} required />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="automation-actions">Actions</Label>
+                <Textarea id="automation-actions" value={actions} onChange={(event) => setActions(event.target.value)} required />
+              </div>
+            </fieldset>
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => setShowCreateAutomationDialog(false)} disabled={isSubmitting}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? "Creating..." : "Create automation"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        {[
+          { title: "Active Automations", value: automations.length, icon: Zap },
+          { title: "Runs This Month", value: 1234, icon: Activity },
+          { title: "AI Accuracy", value: "94%", icon: Brain },
+        ].map((stat) => (
+          <Card key={stat.title} className="bg-white border-[#E2DDD4] shadow-sm">
+            <CardContent className="p-4">
+              <div className="flex items-center gap-3">
+                <div className="w-10 h-10 rounded-lg bg-[#3B8595]/20 flex items-center justify-center">
+                  <stat.icon className="w-5 h-5 text-[#3B8595]" />
+                </div>
+                <div>
+                  <p className="text-2xl font-bold text-black">{stat.value}</p>
+                  <p className="text-sm text-gray-500">{stat.title}</p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <Card className="bg-white border-[#E2DDD4] shadow-sm">
+        <CardContent className="p-4">
+          <p className="text-sm font-semibold text-black mb-3">Current automations</p>
+          {loadingAutomations ? (
+            <p className="text-sm text-gray-500">Loading automations...</p>
+          ) : automations.length === 0 ? (
+            <p className="text-sm text-gray-500">No automations created yet.</p>
+          ) : (
+            <ul className="space-y-2">
+              {automations.map((automation) => (
+                <li key={automation.id} className="rounded-md border border-[#E2DDD4] p-3">
+                  <p className="font-medium text-black">{automation.name}</p>
+                  <p className="text-xs text-gray-600">Trigger: {automation.trigger}</p>
+                  <p className="text-xs text-gray-600">Actions: {automation.actions}</p>
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,7 @@ import { resolve } from 'node:path'
 export default defineConfig({
   test: {
     environment: 'node',
-    include: ['src/**/*.test.ts'],
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
     setupFiles: ['src/test/setup-env.ts'],
   },
   resolve: {


### PR DESCRIPTION
Codex generated this pull request, but encountered an unexpected error after generation. This is a placeholder PR message.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b9ab4723c4832a8556511fc53b805b)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds create-automation flow with a new Automation view and an `/api/automations` endpoint. Users can create automations in a dialog, then see them listed with updated stats.

- **New Features**
  - Added `/api/automations` (GET/POST) with validation and in-memory storage.
  - Built `AutomationView` with create dialog, client-side validation, toasts, and list/stats.
  - Replaced inline view by integrating `AutomationView` in `src/app/page.tsx`.
  - Exposed `openCreateAutomationDialog` and `submitAutomation` helpers with tests; updated `vitest` config to include `.test.tsx`.

<sup>Written for commit 47cf7f78124d6e1ce8edbdd5938bd75fefa8168b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

