### PR TITLE
Codex-generated pull request

### DIFF
--- a/src/app/api/automations/route.test.ts
+++ b/src/app/api/automations/route.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const { mockDb, mockWithRequestOrgContext, mockIsInternalRunnerAuthorized } = vi.hoisted(() => ({
+  mockDb: {
+    automation: {
+      findMany: vi.fn(),
+      create: vi.fn(),
+      findFirst: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    },
+    automationLog: {
+      create: vi.fn(),
+    },
+  },
+  mockWithRequestOrgContext: vi.fn(),
+  mockIsInternalRunnerAuthorized: vi.fn(),
+}))
+
+vi.mock('@/lib/db', () => ({ db: mockDb }))
+vi.mock('@/lib/request-context', () => ({ withRequestOrgContext: mockWithRequestOrgContext }))
+vi.mock('@/lib/internal-runner', () => ({ isInternalRunnerAuthorized: mockIsInternalRunnerAuthorized }))
+
+describe('/api/automations routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockWithRequestOrgContext.mockImplementation(async (_req, handler) =>
+      handler({ organizationId: 'org-1', userId: 'user-1' })
+    )
+  })
+
+  it('rejects invalid create payload via zod validation', async () => {
+    const { POST } = await import('./route')
+    const request = new NextRequest('http://localhost/api/automations', {
+      method: 'POST',
+      body: JSON.stringify({ name: 'Invalid Automation' }),
+      headers: { 'content-type': 'application/json' },
+    })
+
+    const response = await POST(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data.error).toBe('Invalid request body')
+    expect(mockDb.automation.create).not.toHaveBeenCalled()
+  })
+
+  it('scopes list results to request organization', async () => {
+    const { GET } = await import('./route')
+    mockDb.automation.findMany.mockResolvedValueOnce([])
+
+    const response = await GET(new NextRequest('http://localhost/api/automations'))
+
+    expect(response.status).toBe(200)
+    expect(mockDb.automation.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { organizationId: 'org-1' } })
+    )
+  })
+
+  it('blocks patch across org boundaries', async () => {
+    const { PATCH } = await import('./route')
+    mockDb.automation.findFirst.mockResolvedValueOnce(null)
+
+    const request = new NextRequest('http://localhost/api/automations', {
+      method: 'PATCH',
+      body: JSON.stringify({ id: 'automation-2', isActive: false }),
+      headers: { 'content-type': 'application/json' },
+    })
+
+    const response = await PATCH(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(404)
+    expect(data.error).toBe('Automation not found')
+    expect(mockDb.automation.update).not.toHaveBeenCalled()
+  })
+})
+
+describe('/api/automations/run route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockWithRequestOrgContext.mockImplementation(async (_req, handler) =>
+      handler({ organizationId: 'org-1', userId: null })
+    )
+    mockIsInternalRunnerAuthorized.mockReturnValue(true)
+  })
+
+  it('writes execution logs for successful and failed automation runs', async () => {
+    const { POST } = await import('./run/route')
+    mockDb.automation.findMany.mockResolvedValueOnce([
+      {
+        id: 'automation-success',
+        conditions: { score: { gte: 70 } },
+        actions: [{ type: 'send_email' }],
+      },
+      {
+        id: 'automation-fail',
+        conditions: {},
+        actions: [{ type: 'task_create' }],
+      },
+    ])
+    mockDb.automation.update.mockResolvedValueOnce({ id: 'automation-success' }).mockRejectedValueOnce(new Error('boom'))
+    mockDb.automationLog.create.mockResolvedValue({ id: 'log-1' })
+
+    const request = new NextRequest('http://localhost/api/automations/run', {
+      method: 'POST',
+      body: JSON.stringify({ trigger: 'lead_created', input: { score: 90 }, triggeredBy: 'runner' }),
+      headers: { 'content-type': 'application/json', 'x-internal-runner-key': 'abc' },
+    })
+
+    const response = await POST(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.processed).toBe(2)
+    expect(data.succeeded).toBe(1)
+    expect(data.failed).toBe(1)
+    expect(mockDb.automationLog.create).toHaveBeenCalledTimes(2)
+    expect(mockDb.automationLog.create).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        data: expect.objectContaining({ automationId: 'automation-success', success: true, error: null }),
+      })
+    )
+    expect(mockDb.automationLog.create).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        data: expect.objectContaining({ automationId: 'automation-fail', success: false, error: 'boom' }),
+      })
+    )
+  })
+})

--- a/src/app/api/automations/route.ts
+++ b/src/app/api/automations/route.ts
@@ -1,0 +1,147 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { db } from '@/lib/db'
+import { withRequestOrgContext } from '@/lib/request-context'
+import { parseJsonBody } from '@/lib/validation'
+import { enforceRateLimit } from '@/lib/rate-limit'
+
+const automationActionSchema = z.object({
+  type: z.string().min(1),
+}).passthrough()
+
+const jsonRecordSchema = z.record(z.string(), z.unknown())
+
+const createAutomationSchema = z.object({
+  name: z.string().min(1).max(200),
+  description: z.string().max(3000).optional(),
+  trigger: z.string().min(1).max(120),
+  triggerConfig: jsonRecordSchema.optional(),
+  conditions: jsonRecordSchema.nullable().optional(),
+  actions: z.array(automationActionSchema).min(1),
+  isActive: z.boolean().optional(),
+})
+
+const updateAutomationSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1).max(200).optional(),
+  description: z.string().max(3000).nullable().optional(),
+  trigger: z.string().min(1).max(120).optional(),
+  triggerConfig: jsonRecordSchema.nullable().optional(),
+  conditions: jsonRecordSchema.nullable().optional(),
+  actions: z.array(automationActionSchema).min(1).optional(),
+  isActive: z.boolean().optional(),
+})
+
+export async function GET(request: NextRequest) {
+  try {
+    const limited = enforceRateLimit(request, { key: 'automations-list', limit: 100, windowMs: 60_000 })
+    if (limited) return limited
+
+    return withRequestOrgContext(request, async (context) => {
+      const automations = await db.automation.findMany({
+        where: { organizationId: context.organizationId },
+        include: {
+          logs: {
+            orderBy: { createdAt: 'desc' },
+            take: 20,
+          },
+          _count: { select: { logs: true } },
+        },
+        orderBy: { createdAt: 'desc' },
+      })
+
+      return NextResponse.json({ automations })
+    })
+  } catch (error) {
+    console.error('Automations GET error:', error)
+    return NextResponse.json({ error: 'Failed to fetch automations' }, { status: 500 })
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const limited = enforceRateLimit(request, { key: 'automations-create', limit: 60, windowMs: 60_000 })
+    if (limited) return limited
+
+    return withRequestOrgContext(request, async (context) => {
+      const parsed = await parseJsonBody(request, createAutomationSchema)
+      if (!parsed.success) return parsed.response
+
+      const automation = await db.automation.create({
+        data: {
+          organizationId: context.organizationId,
+          name: parsed.data.name.trim(),
+          description: parsed.data.description?.trim() || null,
+          trigger: parsed.data.trigger.trim(),
+          triggerConfig: parsed.data.triggerConfig ?? null,
+          conditions: parsed.data.conditions ?? null,
+          actions: parsed.data.actions,
+          isActive: parsed.data.isActive ?? true,
+        },
+      })
+
+      return NextResponse.json({ automation })
+    })
+  } catch (error) {
+    console.error('Automations POST error:', error)
+    return NextResponse.json({ error: 'Failed to create automation' }, { status: 500 })
+  }
+}
+
+export async function PATCH(request: NextRequest) {
+  try {
+    const limited = enforceRateLimit(request, { key: 'automations-update', limit: 80, windowMs: 60_000 })
+    if (limited) return limited
+
+    return withRequestOrgContext(request, async (context) => {
+      const parsed = await parseJsonBody(request, updateAutomationSchema)
+      if (!parsed.success) return parsed.response
+
+      const { id, ...updates } = parsed.data
+      const existing = await db.automation.findFirst({
+        where: { id, organizationId: context.organizationId },
+      })
+      if (!existing) return NextResponse.json({ error: 'Automation not found' }, { status: 404 })
+
+      const automation = await db.automation.update({
+        where: { id },
+        data: {
+          name: updates.name?.trim(),
+          description: updates.description === undefined ? undefined : updates.description?.trim() || null,
+          trigger: updates.trigger?.trim(),
+          triggerConfig: updates.triggerConfig,
+          conditions: updates.conditions,
+          actions: updates.actions,
+          isActive: updates.isActive,
+        },
+      })
+
+      return NextResponse.json({ automation })
+    })
+  } catch (error) {
+    console.error('Automations PATCH error:', error)
+    return NextResponse.json({ error: 'Failed to update automation' }, { status: 500 })
+  }
+}
+
+export async function DELETE(request: NextRequest) {
+  try {
+    const limited = enforceRateLimit(request, { key: 'automations-delete', limit: 60, windowMs: 60_000 })
+    if (limited) return limited
+
+    return withRequestOrgContext(request, async (context) => {
+      const { searchParams } = new URL(request.url)
+      const id = searchParams.get('id')
+      if (!id) return NextResponse.json({ error: 'id is required' }, { status: 400 })
+
+      const existing = await db.automation.findFirst({ where: { id, organizationId: context.organizationId } })
+      if (!existing) return NextResponse.json({ error: 'Automation not found' }, { status: 404 })
+
+      await db.automation.delete({ where: { id } })
+      return NextResponse.json({ success: true })
+    })
+  } catch (error) {
+    console.error('Automations DELETE error:', error)
+    return NextResponse.json({ error: 'Failed to delete automation' }, { status: 500 })
+  }
+}

--- a/src/app/api/automations/run/route.ts
+++ b/src/app/api/automations/run/route.ts
@@ -1,0 +1,129 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { db } from '@/lib/db'
+import { isInternalRunnerAuthorized } from '@/lib/internal-runner'
+import { withRequestOrgContext } from '@/lib/request-context'
+import { enforceRateLimit } from '@/lib/rate-limit'
+import { parseJsonBody } from '@/lib/validation'
+
+const runAutomationsSchema = z.object({
+  trigger: z.string().min(1).optional(),
+  entityType: z.string().min(1).optional(),
+  entityId: z.string().min(1).optional(),
+  input: z.record(z.string(), z.unknown()).optional(),
+  triggeredBy: z.string().min(1).optional(),
+})
+
+type JsonRecord = Record<string, unknown>
+
+function evaluateConditions(conditions: JsonRecord | null | undefined, input: JsonRecord) {
+  if (!conditions || Object.keys(conditions).length === 0) return true
+
+  for (const [key, condition] of Object.entries(conditions)) {
+    const value = input[key]
+    if (condition && typeof condition === 'object' && !Array.isArray(condition)) {
+      const ops = condition as JsonRecord
+      if (typeof ops.equals !== 'undefined' && value !== ops.equals) return false
+      if (typeof ops.gte !== 'undefined' && typeof value === 'number' && value < Number(ops.gte)) return false
+      if (typeof ops.gte !== 'undefined' && typeof value !== 'number') return false
+      if (typeof ops.lte !== 'undefined' && typeof value === 'number' && value > Number(ops.lte)) return false
+      if (typeof ops.lte !== 'undefined' && typeof value !== 'number') return false
+      if (typeof ops.contains !== 'undefined') {
+        if (typeof value !== 'string' || !value.includes(String(ops.contains))) return false
+      }
+      continue
+    }
+
+    if (value !== condition) return false
+  }
+
+  return true
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const limited = enforceRateLimit(request, { key: 'automation-runner', limit: 40, windowMs: 60_000 })
+    if (limited) return limited
+
+    if (!isInternalRunnerAuthorized(request)) {
+      return NextResponse.json({ error: 'Unauthorized runner request' }, { status: 401 })
+    }
+
+    return withRequestOrgContext(request, async (context) => {
+      const parsed = await parseJsonBody(request, runAutomationsSchema)
+      if (!parsed.success) return parsed.response
+
+      const payload = parsed.data
+      const input = payload.input ?? {}
+      const where = {
+        organizationId: context.organizationId,
+        isActive: true,
+        ...(payload.trigger ? { trigger: payload.trigger.trim() } : {}),
+      }
+
+      const dueAutomations = await db.automation.findMany({
+        where,
+        orderBy: { createdAt: 'asc' },
+        take: 100,
+      })
+
+      let processed = 0
+      let succeeded = 0
+      let failed = 0
+
+      for (const automation of dueAutomations) {
+        const startedAt = Date.now()
+        let success = false
+        let errorMessage: string | null = null
+        let output: JsonRecord = {}
+
+        try {
+          const matched = evaluateConditions((automation.conditions as JsonRecord | null) ?? null, input)
+          if (!matched) {
+            output = { skipped: true, reason: 'conditions_not_matched' }
+          } else {
+            // Placeholder executor: records intended action execution for now.
+            const actions = Array.isArray(automation.actions) ? automation.actions : []
+            output = { executedActions: actions.length, actions }
+
+            await db.automation.update({
+              where: { id: automation.id },
+              data: {
+                executionCount: { increment: 1 },
+                lastExecutedAt: new Date(),
+              },
+            })
+            success = true
+            succeeded++
+          }
+        } catch (error) {
+          success = false
+          failed++
+          errorMessage = error instanceof Error ? error.message : 'Unknown automation execution error'
+        }
+
+        const duration = Date.now() - startedAt
+        await db.automationLog.create({
+          data: {
+            automationId: automation.id,
+            triggeredBy: payload.triggeredBy ?? 'system',
+            entityType: payload.entityType ?? null,
+            entityId: payload.entityId ?? null,
+            input,
+            output,
+            success,
+            duration,
+            error: errorMessage,
+          },
+        })
+
+        processed++
+      }
+
+      return NextResponse.json({ processed, succeeded, failed, totalDue: dueAutomations.length })
+    })
+  } catch (error) {
+    console.error('Automation runner error:', error)
+    return NextResponse.json({ error: 'Failed to execute automations' }, { status: 500 })
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2216,6 +2216,45 @@ function CreateLinearIssueDialog({
 
 // Placeholder views for other sections
 function AutomationView() {
+  type AutomationRow = {
+    id: string
+    name: string
+    trigger: string
+    isActive: boolean
+    executionCount: number
+    logs: Array<{ id: string; success: boolean; error: string | null; duration: number | null; createdAt: string }>
+  }
+
+  const [automations, setAutomations] = useState<AutomationRow[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const fetchAutomations = useCallback(async () => {
+    setLoading(true)
+    try {
+      const response = await fetch('/api/automations')
+      const data = await response.json()
+      if (!response.ok || data.error) throw new Error(data.error || 'Failed to fetch automations')
+      setAutomations(data.automations || [])
+    } catch (error) {
+      toast({
+        title: 'Failed to load automations',
+        description: error instanceof Error ? error.message : 'Unknown error',
+        variant: 'destructive',
+      })
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void fetchAutomations()
+  }, [fetchAutomations])
+
+  const totalRuns = automations.reduce((sum, automation) => sum + automation.executionCount, 0)
+  const totalLogs = automations.reduce((sum, automation) => sum + automation.logs.length, 0)
+  const successfulLogs = automations.flatMap((automation) => automation.logs).filter((log) => log.success).length
+  const successRate = totalLogs > 0 ? `${Math.round((successfulLogs / totalLogs) * 100)}%` : '—'
+
   return (
     <div className="p-6 space-y-6 bg-[#FDFBF7] min-h-screen">
       <div className="flex items-center justify-between">
@@ -2223,17 +2262,17 @@ function AutomationView() {
           <h1 className="text-2xl font-bold text-black">AI Automation</h1>
           <p className="text-gray-500">Automate your workflows with intelligent triggers</p>
         </div>
-        <Button className="btn-gold gap-2">
-          <Plus className="w-4 h-4" />
-          Create Automation
+        <Button className="btn-gold gap-2" onClick={() => void fetchAutomations()}>
+          <RefreshCw className="w-4 h-4" />
+          Refresh
         </Button>
       </div>
-      
+
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
         {[
-          { title: "Active Automations", value: 12, icon: Zap },
-          { title: "Runs This Month", value: 1234, icon: Activity },
-          { title: "AI Accuracy", value: "94%", icon: Brain },
+          { title: 'Active Automations', value: automations.filter((item) => item.isActive).length, icon: Zap },
+          { title: 'Total Runs', value: totalRuns, icon: Activity },
+          { title: 'Recent Success Rate', value: successRate, icon: Brain },
         ].map((stat) => (
           <Card key={stat.title} className="bg-white border-[#E2DDD4] shadow-sm">
             <CardContent className="p-4">
@@ -2250,6 +2289,61 @@ function AutomationView() {
           </Card>
         ))}
       </div>
+
+      <Card className="bg-white border-[#E2DDD4] shadow-sm">
+        <CardHeader>
+          <CardTitle>Automations</CardTitle>
+          <CardDescription>Live automations configured for your organization.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {loading && <p className="text-sm text-gray-500">Loading automations...</p>}
+          {!loading && automations.length === 0 && <p className="text-sm text-gray-500">No automations found.</p>}
+          {!loading && automations.map((automation) => (
+            <div key={automation.id} className="border border-[#E2DDD4] rounded-lg p-3">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="font-semibold text-black">{automation.name}</p>
+                  <p className="text-xs text-gray-500">Trigger: {automation.trigger}</p>
+                </div>
+                <Badge variant={automation.isActive ? 'default' : 'secondary'}>
+                  {automation.isActive ? 'Active' : 'Paused'}
+                </Badge>
+              </div>
+              <p className="mt-2 text-xs text-gray-600">Runs: {automation.executionCount}</p>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+
+      <Card className="bg-white border-[#E2DDD4] shadow-sm">
+        <CardHeader>
+          <CardTitle>Recent Execution Logs</CardTitle>
+          <CardDescription>Latest run logs across all automations.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          {automations
+            .flatMap((automation) => automation.logs.map((log) => ({ ...log, automationName: automation.name })))
+            .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+            .slice(0, 10)
+            .map((log) => (
+              <div key={log.id} className="flex items-center justify-between border border-[#E2DDD4] rounded-md p-2">
+                <div>
+                  <p className="text-sm font-medium text-black">{log.automationName}</p>
+                  <p className="text-xs text-gray-500">{new Date(log.createdAt).toLocaleString()}</p>
+                </div>
+                <div className="text-right">
+                  <p className={cn('text-xs font-semibold', log.success ? 'text-green-600' : 'text-red-600')}>
+                    {log.success ? 'Success' : 'Failed'}
+                  </p>
+                  <p className="text-xs text-gray-500">{log.duration ?? 0}ms</p>
+                </div>
+              </div>
+            ))}
+          {!loading && automations.length > 0 && automations.every((automation) => automation.logs.length === 0) && (
+            <p className="text-sm text-gray-500">No execution logs yet.</p>
+          )}
+        </CardContent>
+      </Card>
     </div>
   )
 }


### PR DESCRIPTION
Codex generated this pull request, but encountered an unexpected error after generation. This is a placeholder PR message.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b9ab4b3470832a850914005b838d3c)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds organization-scoped Automation APIs and an internal runner with execution logging, plus a lightweight dashboard to view automations and recent runs. This enables creating, updating, deleting, and executing automations safely within an org.

- **New Features**
  - CRUD API at `/api/automations` with zod validation, org scoping, and per-route rate limits.
  - Update and delete guard against cross-org access; list includes recent logs and counts.
  - Runner endpoint at `/api/automations/run` secured by internal runner auth; evaluates simple conditions (`equals`, `gte`, `lte`, `contains`), updates `executionCount`/`lastExecutedAt`, and writes detailed logs (success, error, duration).
  - Tests cover payload validation, org scoping, update protections, and logging for successful/failed runs.
  - Dashboard updates: Automation list with status and run counts, recent execution logs, quick stats, and a Refresh action.

<sup>Written for commit d28dd3ad47be92b941aec84fdcdbc797cb235c1b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

