### PR TITLE
Codex-generated pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,8 @@ jobs:
             bun install --frozen-lockfile
           fi
 
-      - name: Run typecheck
-        run: bun run typecheck
+      - name: Run typecheck (strict, no baseline)
+        run: bunx tsc --noEmit --project tsconfig.typecheck.json --pretty false
 
   test:
     name: test

--- a/README.md
+++ b/README.md
@@ -72,6 +72,21 @@ bun start
 
 Open [http://localhost:3000](http://localhost:3000) to see your application running.
 
+## ✅ Type safety policy
+
+Type safety is strictly enforced in local development and CI:
+
+- `bun run typecheck` runs `tsc --noEmit --project tsconfig.typecheck.json`.
+- There is no TypeScript-error allowlist/baseline: any TS error fails the check.
+- The CI `typecheck` job is a required status check and fails on any TypeScript error.
+
+Run this before opening a PR:
+
+```bash
+bun run typecheck
+```
+
+
 ## 🤖 Powered by Z.ai
 
 This scaffold is optimized for use with [Z.ai](https://chat.z.ai) - your AI assistant for:

--- a/scripts/typecheck-gate.mjs
+++ b/scripts/typecheck-gate.mjs
@@ -2,55 +2,16 @@
 
 import { spawnSync } from "node:child_process";
 
-const baselineErrors = new Set([
-  "src/app/api/activities/route.ts|TS2322|Type 'Record<string, unknown> | undefined' is not assignable to type 'NullableJsonNullValueInput | InputJsonValue | undefined'.",
-  "src/app/api/ai/carrier-playbook/route.ts|TS2322|Type '({ score: number; carrierId: string; carrierName: string; documentId: string; documentName: string; chunkIndex: number; content: string; } | null)[]' is not assignable to type 'RetrievedChunk[]'.",
-  "src/app/api/ai/carrier-playbook/route.ts|TS2677|A type predicate's type must be assignable to its parameter's type.",
-  "src/app/api/ai/carrier-playbook/route.ts|TS18047|'b' is possibly 'null'.",
-  "src/app/api/ai/carrier-playbook/route.ts|TS18047|'a' is possibly 'null'.",
-  "src/app/api/ai/feedback/route.ts|TS2322|Type 'Record<string, unknown> | null' is not assignable to type 'NullableJsonNullValueInput | InputJsonValue | undefined'.",
-  "src/app/api/ai/route.ts|TS2488|Type 'unknown' must have a '[Symbol.iterator]()' method that returns an iterator.",
-  "src/app/api/bookings/route.ts|TS2322|Type 'string | null' is not assignable to type 'string | undefined'.",
-  "src/app/api/carriers/[id]/documents/route.ts|TS2339|Property 'default' does not exist on type 'typeof import(\"/workspace/node_modules/pdf-parse/dist/pdf-parse/esm/index\")'.",
-  "src/app/api/content/route.ts|TS2322|Type '{ title?: string | null | undefined; content?: string | undefined; status?: string | undefined; platform?: string | undefined; scheduledFor?: Date | null | undefined; publishedAt?: Date | ... 1 more ... | undefined; publishedUrl?: string | ... 1 more ... | undefined; mediaUrls?: string[] | ... 1 more ... | undefined...' is not assignable to type '(Without<ContentQueueUpdateManyMutationInput, ContentQueueUncheckedUpdateManyInput> & ContentQueueUncheckedUpdateManyInput) | (Without<...> & ContentQueueUpdateManyMutationInput)'.",
-  "src/app/api/leads/route.ts|TS2322|Type 'Record<string, unknown> | undefined' is not assignable to type 'NullableJsonNullValueInput | InputJsonValue | undefined'.",
-  "src/app/api/upload/route.ts|TS2322|Type 'InputJsonValue | null' is not assignable to type 'NullableJsonNullValueInput | InputJsonValue | undefined'.",
-  "src/app/api/upload/route.ts|TS2322|Type 'InputJsonValue | null' is not assignable to type 'NullableJsonNullValueInput | InputJsonValue | undefined'.",
-]);
-
 const result = spawnSync(
   "bunx",
   ["tsc", "--noEmit", "--project", "tsconfig.typecheck.json", "--pretty", "false"],
-  { encoding: "utf8" },
+  { encoding: "utf8", stdio: "inherit" },
 );
 
-const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
-const matches = [...output.matchAll(/^(.+)\(\d+,\d+\): error (TS\d+): (.+)$/gm)];
-const observedErrors = matches.map(([, file, code, message]) => `${file}|${code}|${message}`);
-
 if (result.error) {
-  console.error("Typecheck gate failed to execute tsc.");
+  console.error("Typecheck failed to execute tsc.");
   console.error(result.error);
   process.exit(1);
 }
 
-if (observedErrors.length === 0) {
-  console.log("Typecheck passed with zero TypeScript errors.");
-  process.exit(result.status ?? 0);
-}
-
-const unknownErrors = observedErrors.filter((entry) => !baselineErrors.has(entry));
-
-if (unknownErrors.length > 0) {
-  console.error("Typecheck gate found NEW TypeScript errors:");
-  for (const entry of unknownErrors) {
-    console.error(`- ${entry}`);
-  }
-  console.error("\nFull tsc output:\n");
-  console.error(output);
-  process.exit(1);
-}
-
-console.log(
-  `Typecheck gate passed with ${observedErrors.length} known baseline TypeScript errors.`,
-);
+process.exit(result.status ?? 1);

--- a/src/app/api/activities/route.ts
+++ b/src/app/api/activities/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import type { Prisma } from '@prisma/client'
 import { db } from '@/lib/db'
 import { withRequestOrgContext } from '@/lib/request-context'
 import { z } from 'zod'
@@ -93,7 +94,7 @@ export async function POST(request: NextRequest) {
         type: body.type,
         title: body.title,
         description: body.description,
-        metadata: body.metadata,
+        metadata: body.metadata as Prisma.InputJsonValue | undefined,
         aiSummary: body.aiSummary
       },
       include: {

--- a/src/app/api/ai/carrier-playbook/route.ts
+++ b/src/app/api/ai/carrier-playbook/route.ts
@@ -125,6 +125,9 @@ type KnowledgeCitation = {
   chunkIndex: number
   snippet: string
 }
+function isRetrievedChunk(value: RetrievedChunk | null): value is RetrievedChunk {
+  return value !== null
+}
 
 function tokenize(text: string): string[] {
   return (text.toLowerCase().match(/[a-z0-9]{3,}/g) || []).slice(0, 500)
@@ -177,7 +180,7 @@ function retrieveTopChunks(
   if (queryTokens.length === 0) return []
   const queryTokenSet = new Set(queryTokens)
 
-  const scored: RetrievedChunk[] = chunks
+  const scored = chunks
     .map((chunk) => {
       const chunkTokens = tokenize(chunk.content)
       if (chunkTokens.length === 0) return null
@@ -202,7 +205,7 @@ function retrieveTopChunks(
         content: chunk.content,
       }
     })
-    .filter((c): c is RetrievedChunk => !!c)
+    .filter(isRetrievedChunk)
     .sort((a, b) => b.score - a.score)
 
   return scored

--- a/src/app/api/ai/feedback/route.ts
+++ b/src/app/api/ai/feedback/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import type { Prisma } from '@prisma/client'
 import { db } from '@/lib/db'
 import { z } from 'zod'
 import { parseJsonBody } from '@/lib/validation'
@@ -26,7 +27,7 @@ export async function POST(request: NextRequest) {
         entityId,
         rating,
         feedback: feedback || null,
-        corrections: corrections || null,
+        corrections: (corrections ?? undefined) as Prisma.InputJsonValue | Prisma.NullableJsonNullValueInput | undefined,
       },
     })
 

--- a/src/app/api/ai/route.ts
+++ b/src/app/api/ai/route.ts
@@ -20,6 +20,18 @@ function extractJsonObject(text: string | null): Record<string, unknown> | null 
   }
 }
 
+
+function isChatMessageArray(value: unknown): value is Array<{ role: 'system' | 'user' | 'assistant'; content: string }> {
+  return Array.isArray(value) && value.every((item) => {
+    if (!item || typeof item !== 'object') return false
+    const candidate = item as { role?: unknown; content?: unknown }
+    return (
+      typeof candidate.content === 'string' &&
+      (candidate.role === 'system' || candidate.role === 'user' || candidate.role === 'assistant')
+    )
+  })
+}
+
 // AI API using z-ai-web-dev-sdk
 export async function POST(request: NextRequest) {
   try {
@@ -192,7 +204,8 @@ Provide 3-5 insights in JSON format:
       
       case 'chat': {
         const { messages, context } = data
-        
+        const safeMessages = isChatMessageArray(messages) ? messages : []
+
         const systemPrompt = `You are an AI assistant for EliteCRM, a sophisticated CRM system.
 You help users manage leads, analyze data, and optimize their sales process.
 Be concise, professional, and actionable in your responses.
@@ -200,7 +213,7 @@ Context: ${JSON.stringify(context)}`
 
         const responseText = await zaiChatMessages([
           { role: 'system', content: systemPrompt },
-          ...messages,
+          ...safeMessages,
         ])
 
         return NextResponse.json({

--- a/src/app/api/bookings/route.ts
+++ b/src/app/api/bookings/route.ts
@@ -85,7 +85,7 @@ export async function POST(request: NextRequest) {
           },
         })
       }
-      resolvedLeadId = lead?.id ?? null
+      resolvedLeadId = lead?.id
     }
 
     const activity = await db.activity.create({

--- a/src/app/api/carriers/[id]/documents/route.ts
+++ b/src/app/api/carriers/[id]/documents/route.ts
@@ -123,8 +123,7 @@ async function extractCarrierText(file: File, buffer: Buffer): Promise<string> {
 
   if (fileType.includes('pdf') || fileName.endsWith('.pdf')) {
     try {
-      const pdfParseModule = await import('pdf-parse')
-      const pdfParse = (pdfParseModule.default || pdfParseModule) as unknown as (input: Buffer) => Promise<{ text?: string }>
+      const pdfParse = (await import('pdf-parse')) as unknown as (input: Buffer) => Promise<{ text?: string }>
       const parsed = await pdfParse(buffer)
       return parsed.text || ''
     } catch (pdfError) {

--- a/src/app/api/content/route.ts
+++ b/src/app/api/content/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import type { Prisma } from '@prisma/client'
 import { db } from '@/lib/db'
 import { withRequestOrgContext } from '@/lib/request-context'
 import { z } from 'zod'
@@ -123,16 +124,7 @@ export async function PATCH(request: NextRequest) {
     const parsed = await parseJsonBody(request, patchContentSchema)
     if (!parsed.success) return parsed.response
     const body = parsed.data
-    const updateData: {
-      title?: string | null
-      content?: string
-      status?: string
-      platform?: string
-      scheduledFor?: Date | null
-      publishedAt?: Date | null
-      publishedUrl?: string | null
-      mediaUrls?: string[] | null
-    } = {}
+    const updateData: Prisma.ContentQueueUpdateManyMutationInput = {}
 
     if (typeof body.title === 'string') updateData.title = body.title.trim() || null
     if (typeof body.content === 'string') updateData.content = body.content.trim()

--- a/src/app/api/leads/route.ts
+++ b/src/app/api/leads/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import type { Prisma } from '@prisma/client'
 import { db } from '@/lib/db'
 import { withRequestOrgContext } from '@/lib/request-context'
 import { z } from 'zod'
@@ -97,7 +98,7 @@ export async function POST(request: NextRequest) {
         source: body.source || 'manual',
         status: 'new',
         estimatedValue: body.estimatedValue,
-        customFields: body.customFields,
+        customFields: body.customFields as Prisma.InputJsonValue | undefined,
         aiScore: 0, // Will be calculated by AI
       }
     })

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -315,8 +315,8 @@ export async function POST(request: NextRequest) {
           successfulRows,
           failedRows,
           duplicateRows,
-          errors: errors.length > 0 ? (errors as Prisma.InputJsonValue) : null,
-          warnings: warnings.length > 0 ? (warnings as Prisma.InputJsonValue) : null,
+          errors: errors.length > 0 ? (errors as Prisma.InputJsonValue) : undefined,
+          warnings: warnings.length > 0 ? (warnings as Prisma.InputJsonValue) : undefined,
           completedAt: new Date(),
         },
       })


### PR DESCRIPTION
Codex generated this pull request, but encountered an unexpected error after generation. This is a placeholder PR message.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b9b156a994832aa39db5fdf4d92755)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces a strict, no-baseline TypeScript typecheck in CI and cleans up type issues across API routes. Updates docs and CI to run `bunx tsc` directly and tightens Prisma JSON typing.

- **Refactors**
  - CI now runs `bunx tsc --noEmit --project tsconfig.typecheck.json`; removed baseline logic from `scripts/typecheck-gate.mjs`.
  - README adds a “Type safety policy” and `bun run typecheck` guidance.
  - Prisma JSON typing hardened: `activities`, `leads`, `ai/feedback`, `upload`, and `content` (now uses `Prisma.ContentQueueUpdateManyMutationInput`).
  - Type guards added: chat messages validation in `ai/route` and retrieved chunks in `ai/carrier-playbook`.
  - Minor fixes: correct `pdf-parse` dynamic import, null→undefined adjustments in `bookings` and `upload`.

- **Migration**
  - Run `bun run typecheck` locally before opening PRs.
  - Fix all TypeScript errors; there is no allowlist and CI will fail on any error.

<sup>Written for commit 6dd176f557e6123902ce9e276c2e5b4e09be255f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

