### PR TITLE
Codex-generated pull request

### DIFF
--- a/src/app/api/auth/route.test.ts
+++ b/src/app/api/auth/route.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest, NextResponse } from 'next/server'
+import { pbkdf2Sync } from 'node:crypto'
+
+const mockDb = vi.hoisted(() => ({
+  user: {
+    findFirst: vi.fn(),
+    create: vi.fn(),
+  },
+  organization: {
+    create: vi.fn(),
+    findUnique: vi.fn(),
+  },
+  userSession: {
+    create: vi.fn(),
+    updateMany: vi.fn(),
+    findFirst: vi.fn(),
+  },
+}))
+
+const mockEnforceRateLimit = vi.hoisted(() => vi.fn())
+
+vi.mock('@/lib/db', () => ({
+  db: mockDb,
+}))
+
+vi.mock('@/lib/rate-limit', () => ({
+  enforceRateLimit: mockEnforceRateLimit,
+}))
+
+import { POST } from './route'
+
+function hashPassword(password: string, salt: string) {
+  return pbkdf2Sync(password, salt, 100_000, 32, 'sha256').toString('hex')
+}
+
+describe('POST /api/auth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockEnforceRateLimit.mockReturnValue(null)
+  })
+
+  it('returns rate-limit response for signin when limit is exceeded', async () => {
+    mockEnforceRateLimit.mockReturnValueOnce(
+      NextResponse.json({ error: 'Too many requests, please retry later' }, { status: 429 })
+    )
+
+    const request = new NextRequest('http://localhost/api/auth', {
+      method: 'POST',
+      body: JSON.stringify({ action: 'signin', email: 'agent@example.com', password: 'secret' }),
+    })
+
+    const response = await POST(request)
+    expect(response.status).toBe(429)
+    await expect(response.json()).resolves.toEqual({ error: 'Too many requests, please retry later' })
+    expect(mockDb.user.findFirst).not.toHaveBeenCalled()
+  })
+
+  it('returns 401 for invalid credentials', async () => {
+    const salt = 'a'.repeat(32)
+    mockDb.user.findFirst.mockResolvedValueOnce({
+      id: 'user_1',
+      email: 'agent@example.com',
+      name: 'Agent',
+      role: 'owner',
+      organizationId: 'org_1',
+      preferences: {
+        salt,
+        passwordHash: hashPassword('correct-password', salt),
+      },
+      organization: { id: 'org_1', name: 'Org', slug: 'org' },
+    })
+
+    const request = new NextRequest('http://localhost/api/auth', {
+      method: 'POST',
+      body: JSON.stringify({ action: 'signin', email: 'agent@example.com', password: 'wrong-password' }),
+    })
+
+    const response = await POST(request)
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toEqual({ error: 'Invalid email or password' })
+    expect(mockDb.userSession.create).not.toHaveBeenCalled()
+  })
+
+  it('creates a session and sets secure cookie attributes on successful signin', async () => {
+    const salt = 'b'.repeat(32)
+    mockDb.user.findFirst.mockResolvedValueOnce({
+      id: 'user_1',
+      email: 'agent@example.com',
+      name: 'Agent',
+      role: 'owner',
+      organizationId: 'org_1',
+      preferences: {
+        salt,
+        passwordHash: hashPassword('correct-password', salt),
+      },
+      organization: { id: 'org_1', name: 'Org', slug: 'org' },
+    })
+
+    const request = new NextRequest('http://localhost/api/auth', {
+      method: 'POST',
+      body: JSON.stringify({ action: 'signin', email: 'agent@example.com', password: 'correct-password' }),
+    })
+
+    const response = await POST(request)
+
+    expect(response.status).toBe(200)
+    expect(mockDb.userSession.create).toHaveBeenCalledTimes(1)
+
+    const setCookie = response.headers.get('set-cookie')
+    expect(setCookie).toContain('session-token=')
+    expect(setCookie).toContain('HttpOnly')
+    expect(setCookie).toContain('SameSite=Lax')
+    expect(setCookie).toContain('Path=/')
+    expect(setCookie).toContain('Max-Age=604800')
+  })
+})

--- a/src/app/api/auth/route.ts
+++ b/src/app/api/auth/route.ts
@@ -1,6 +1,63 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { db } from '@/lib/db'
-import { randomBytes, pbkdf2Sync, createHash } from 'node:crypto'
+import { randomBytes, pbkdf2Sync, timingSafeEqual } from 'node:crypto'
+import { enforceRateLimit } from '@/lib/rate-limit'
+
+const SESSION_MAX_AGE_SECONDS = 7 * 24 * 60 * 60
+const FAILED_SIGNIN_LOCKOUT_BASE_MS = 15_000
+const FAILED_SIGNIN_LOCKOUT_MAX_MS = 5 * 60_000
+const failedSigninAttempts = new Map<string, { count: number; lockoutUntil: number }>()
+
+function setSessionCookie(response: NextResponse, token: string, maxAge = SESSION_MAX_AGE_SECONDS) {
+  response.cookies.set('session-token', token, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: '/',
+    maxAge,
+  })
+}
+
+function clearSessionCookie(response: NextResponse) {
+  response.cookies.set('session-token', '', {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: '/',
+    maxAge: 0,
+  })
+}
+
+function isLockedOut(email: string) {
+  const now = Date.now()
+  const attempt = failedSigninAttempts.get(email)
+  if (!attempt) return null
+  if (attempt.lockoutUntil <= now) {
+    failedSigninAttempts.delete(email)
+    return null
+  }
+  return Math.ceil((attempt.lockoutUntil - now) / 1000)
+}
+
+function recordFailedSignin(email: string) {
+  const now = Date.now()
+  const existing = failedSigninAttempts.get(email)
+  const nextCount = (existing?.count || 0) + 1
+  const backoff = Math.min(FAILED_SIGNIN_LOCKOUT_BASE_MS * Math.max(1, nextCount - 2), FAILED_SIGNIN_LOCKOUT_MAX_MS)
+  failedSigninAttempts.set(email, {
+    count: nextCount,
+    lockoutUntil: now + backoff,
+  })
+}
+
+function resetFailedSignin(email: string) {
+  failedSigninAttempts.delete(email)
+}
+
+function hashesMatch(attemptHash: string, storedHash: string) {
+  if (attemptHash.length !== storedHash.length) return false
+  return timingSafeEqual(Buffer.from(attemptHash, 'utf8'), Buffer.from(storedHash, 'utf8'))
+}
 
 function hashPassword(password: string, salt: string): string {
   // Derive a password hash using PBKDF2 to make brute-force attacks more expensive.
@@ -29,6 +86,9 @@ export async function POST(request: NextRequest) {
     const { action } = body
 
     if (action === 'signup') {
+      const limited = enforceRateLimit(request, { key: 'auth-signup', limit: 5, windowMs: 10 * 60_000 })
+      if (limited) return limited
+
       const { email, password, name, orgName } = body
       if (!email?.trim() || !password || password.length < 6) {
         return NextResponse.json({ error: 'Email and password (min 6 chars) are required' }, { status: 400 })
@@ -70,7 +130,7 @@ export async function POST(request: NextRequest) {
           userId: user.id,
           token,
           isActive: true,
-          expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+          expiresAt: new Date(Date.now() + SESSION_MAX_AGE_SECONDS * 1000),
         },
       })
 
@@ -78,28 +138,34 @@ export async function POST(request: NextRequest) {
         user: { id: user.id, email: user.email, name: user.name, role: user.role, organizationId: org.id },
         organization: { id: org.id, name: org.name, slug: org.slug },
       })
-      response.cookies.set('session-token', token, {
-        httpOnly: true,
-        secure: process.env.NODE_ENV === 'production',
-        sameSite: 'lax',
-        maxAge: 30 * 24 * 60 * 60,
-        path: '/',
-      })
+      setSessionCookie(response, token)
       return response
     }
 
     if (action === 'signin') {
+      const limited = enforceRateLimit(request, { key: 'auth-signin', limit: 10, windowMs: 5 * 60_000 })
+      if (limited) return limited
+
       const { email, password } = body
       if (!email?.trim() || !password) {
         return NextResponse.json({ error: 'Email and password are required' }, { status: 400 })
       }
 
       const normalizedEmail = email.trim().toLowerCase()
+      const retryAfterSec = isLockedOut(normalizedEmail)
+      if (retryAfterSec) {
+        return NextResponse.json(
+          { error: 'Too many failed sign-in attempts. Please wait and try again.' },
+          { status: 429, headers: { 'Retry-After': String(retryAfterSec) } }
+        )
+      }
+
       const user = await db.user.findFirst({
         where: { email: normalizedEmail },
         include: { organization: true },
       })
       if (!user) {
+        recordFailedSignin(normalizedEmail)
         return NextResponse.json({ error: 'Invalid email or password' }, { status: 401 })
       }
 
@@ -107,13 +173,17 @@ export async function POST(request: NextRequest) {
       const storedHash = prefs.passwordHash
       const salt = prefs.salt
       if (!storedHash || !salt) {
+        recordFailedSignin(normalizedEmail)
         return NextResponse.json({ error: 'Account not set up for password login' }, { status: 401 })
       }
 
       const attemptHash = hashPassword(password, salt)
-      if (attemptHash !== storedHash) {
+      if (!hashesMatch(attemptHash, storedHash)) {
+        recordFailedSignin(normalizedEmail)
         return NextResponse.json({ error: 'Invalid email or password' }, { status: 401 })
       }
+
+      resetFailedSignin(normalizedEmail)
 
       const token = generateToken()
       await db.userSession.create({
@@ -121,7 +191,7 @@ export async function POST(request: NextRequest) {
           userId: user.id,
           token,
           isActive: true,
-          expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+          expiresAt: new Date(Date.now() + SESSION_MAX_AGE_SECONDS * 1000),
         },
       })
 
@@ -129,13 +199,7 @@ export async function POST(request: NextRequest) {
         user: { id: user.id, email: user.email, name: user.name, role: user.role, organizationId: user.organizationId },
         organization: user.organization ? { id: user.organization.id, name: user.organization.name, slug: user.organization.slug } : null,
       })
-      response.cookies.set('session-token', token, {
-        httpOnly: true,
-        secure: process.env.NODE_ENV === 'production',
-        sameSite: 'lax',
-        maxAge: 30 * 24 * 60 * 60,
-        path: '/',
-      })
+      setSessionCookie(response, token)
       return response
     }
 
@@ -145,7 +209,7 @@ export async function POST(request: NextRequest) {
         await db.userSession.updateMany({ where: { token }, data: { isActive: false } })
       }
       const response = NextResponse.json({ success: true })
-      response.cookies.set('session-token', '', { maxAge: 0, path: '/' })
+      clearSessionCookie(response)
       return response
     }
 


### PR DESCRIPTION
Codex generated this pull request, but encountered an unexpected error after generation. This is a placeholder PR message.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b9b157d7f4832a980376ab158bef64)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the auth API with rate limiting, lockout, timing-safe password checks, and secure session cookies. Added tests for rate limits, invalid credentials, and cookie attributes.

- **New Features**
  - Rate limits: signup 5/10m and signin 10/5m via `@/lib/rate-limit` (returns 429 when exceeded).
  - Progressive lockout on failed signins with backoff up to 5m; responds 429 with `Retry-After`.
  - Secure session cookies: `HttpOnly`, `SameSite=Lax`, `Secure` in production; 7‑day TTL; cleared on signout; DB session expiry matches.
  - Timing-safe password comparison using `timingSafeEqual` to mitigate timing attacks.
  - Tests (`vitest`) for signin rate limit, invalid credentials (401), and cookie flags on successful signin.

<sup>Written for commit 94a6f633a3d1bbd928974b003036d1e6bad8b665. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

