### PR TITLE
Support JWT-backed session tokens and update session management

### DIFF
--- a/src/app/api/security/sessions/route.ts
+++ b/src/app/api/security/sessions/route.ts
@@ -1,8 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { db } from '@/lib/db'
 import { withRequestOrgContext } from '@/lib/request-context'
-import { AUTH_COOKIE_NAME } from '@/lib/auth'
-import { hashSessionToken } from '@/lib/auth'
+import { AUTH_COOKIE_NAME, getCurrentSessionFromToken, hashSessionToken } from '@/lib/auth'
 import { enforceRateLimit } from '@/lib/rate-limit'
 
 export async function GET(request: NextRequest) {
@@ -11,7 +10,12 @@ export async function GET(request: NextRequest) {
       if (!context.userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
       const currentToken = request.cookies.get(AUTH_COOKIE_NAME)?.value?.trim() || null
-      const currentTokenHash = currentToken ? hashSessionToken(currentToken) : null
+      const currentSession = currentToken ? await getCurrentSessionFromToken(currentToken) : null
+      const currentTokenHash = currentSession
+        ? hashSessionToken(currentSession.sessionToken)
+        : currentToken
+          ? hashSessionToken(currentToken)
+          : null
 
       const sessions = await db.userSession.findMany({
         where: {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,5 +1,6 @@
 import { createHash, randomBytes, scryptSync, timingSafeEqual } from 'node:crypto'
 import type { Prisma } from '@prisma/client'
+import { decode as decodeJwt } from 'next-auth/jwt'
 import { NextRequest } from 'next/server'
 import { cookies } from 'next/headers'
 import { db } from '@/lib/db'
@@ -148,7 +149,20 @@ export function readSessionClientDetails(request: NextRequest) {
 }
 
 export async function getCurrentSessionFromToken(token: string) {
-  const tokenHash = hashSessionToken(token)
+  let lookupToken = token
+
+  const authSecret = process.env.NEXTAUTH_SECRET?.trim()
+  if (authSecret) {
+    const decoded = await decodeJwt({
+      token,
+      secret: authSecret,
+    }).catch(() => null)
+    if (decoded && typeof decoded.sessionToken === 'string' && decoded.sessionToken.length > 0) {
+      lookupToken = decoded.sessionToken
+    }
+  }
+
+  const tokenHash = hashSessionToken(lookupToken)
 
   const session = await db.userSession.findFirst({
     where: {
@@ -197,7 +211,7 @@ export async function getCurrentSessionFromToken(token: string) {
 
   return {
     sessionId: session.id,
-    sessionToken: token,
+    sessionToken: lookupToken,
     sessionTokenHash: session.token,
     expiresAt: session.expiresAt,
     user: session.user,

--- a/src/lib/next-auth.ts
+++ b/src/lib/next-auth.ts
@@ -8,7 +8,10 @@ import { getAuthSecret } from '@/lib/auth-env'
 import {
   AUTH_COOKIE_NAME,
   SESSION_TTL_MS,
+  createSessionToken,
+  createUserSession,
   hashSessionToken,
+  invalidateSessionToken,
   readUserPreferences,
   readSessionClientDetails,
   serializeAuthUser,
@@ -263,7 +266,7 @@ export function buildNextAuthOptions(request?: NextRequest): NextAuthOptions {
     secret: getAuthSecret(),
     adapter: createPrismaAuthAdapter(request),
     session: {
-      strategy: 'database',
+      strategy: 'jwt',
       maxAge: Math.floor(SESSION_TTL_MS / 1000),
     },
     providers: [
@@ -318,6 +321,13 @@ export function buildNextAuthOptions(request?: NextRequest): NextAuthOptions {
           preferences: unknown
         }
 
+        const existingSessionToken =
+          typeof token.sessionToken === 'string' && token.sessionToken.length > 0 ? token.sessionToken : null
+        const sessionToken = existingSessionToken ?? createSessionToken()
+        if (!existingSessionToken) {
+          await createUserSession(u.id, sessionToken, request)
+        }
+
         token.sub = u.id
         token.email = u.email
         token.name = u.name
@@ -326,6 +336,7 @@ export function buildNextAuthOptions(request?: NextRequest): NextAuthOptions {
         token.organizationId = u.organizationId
         token.organization = u.organization
         token.preferences = u.preferences
+        token.sessionToken = sessionToken
 
         return token
       },
@@ -371,6 +382,14 @@ export function buildNextAuthOptions(request?: NextRequest): NextAuthOptions {
         session.user.preferences = preferences
         session.user.mustChangePassword = readUserPreferences(preferences).requirePasswordChange === true
         return session
+      },
+    },
+    events: {
+      async signOut(message) {
+        const token = message?.token as { sessionToken?: unknown } | undefined
+        const sessionToken =
+          typeof token?.sessionToken === 'string' && token.sessionToken.length > 0 ? token.sessionToken : null
+        if (sessionToken) await invalidateSessionToken(sessionToken)
       },
     },
   }


### PR DESCRIPTION
### Motivation
- Ensure session lookups work when NextAuth issues JWT-encoded session tokens and allow invalidation on sign-out.
- Move session token handling into shared auth helpers to centralize token creation, decoding, lookup, and invalidation.

### Description
- Add `getCurrentSessionFromToken` to decode JWT session tokens (when `NEXTAUTH_SECRET` is present) and look up the corresponding `userSession` record; return a normalized session object and update last activity timestamps.  
- Update the sessions API (`/api/security/sessions`) to use `getCurrentSessionFromToken` and compute the correct token hash for the current session.  
- Switch NextAuth session `strategy` from `database` to `jwt`, generate or reuse a `sessionToken` in the `jwt` callback, create a `userSession` via `createUserSession` when needed, and attach `sessionToken` into the token payload.  
- Add an `events.signOut` handler to invalidate the underlying `userSession` via `invalidateSessionToken` when a sign-out occurs.  
- Minor import and helper reorganizations (`hashSessionToken`, new auth helpers, and JWT decoding via `next-auth/jwt`).

### Testing
- Ran TypeScript build (`npm run build`) to validate types and compilation, which completed successfully.  
- Executed the repository test suite (`npm test`) and existing automated tests, which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5cace5580832ab01e27ba7c9a0567)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches `next-auth` to JWT sessions and persists DB-backed sessions for reliable lookups and sign-out invalidation. Centralizes token creation, decoding, lookup, and invalidation in shared auth helpers.

- New Features
  - Added `getCurrentSessionFromToken` to decode JWTs (via `next-auth/jwt`), resolve the underlying `userSession`, normalize the session, and update last-activity.
  - Updated `/api/security/sessions` to use the resolved session and compute the correct token hash for the current session.
  - Changed `session.strategy` to `jwt`; generate or reuse a `sessionToken` in the `jwt` callback, create `userSession` when needed, and embed `sessionToken` in the JWT.
  - Implemented `events.signOut` to invalidate the `userSession` via `invalidateSessionToken`.

<sup>Written for commit f00b985c59badd50b4676b83b02f04b3c63665e3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

