### PR TITLE
Make client API calls base-path aware for upload and scrape

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -49,7 +49,7 @@ import { SettingsView } from "@/components/settings/settings-view"
 import { AiAssistantView } from "@/components/ai/ai-assistant-view"
 import { triggerWinCelebration, triggerSmallCelebration } from "@/lib/celebrations"
 import { toast } from "@/hooks/use-toast"
-import { readApiJsonOrText } from "@/lib/api-client"
+import { buildApiPath, readApiJsonOrText } from "@/lib/api-client"
 
 // ============================================
 // ELITE CRM - MODERN OCEAN THEME
@@ -1697,7 +1697,7 @@ function UploadsView({ onUploadCSV, refreshKey = 0 }: { onUploadCSV: () => void;
     let cancelled = false
     ;(async () => {
       try {
-        const res = await fetch('/api/upload?limit=100')
+        const res = await fetch(buildApiPath('/api/upload?limit=100'))
         const { data, text } = await readApiJsonOrText(res)
         if (cancelled) return
         if (!data) {

--- a/src/components/app/use-workspace-overlays.ts
+++ b/src/components/app/use-workspace-overlays.ts
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useState } from "react"
 import { useCommandPalette } from "@/components/command-palette"
 import { toast } from "@/hooks/use-toast"
-import { readApiJsonOrText } from "@/lib/api-client"
+import { buildApiPath, readApiJsonOrText } from "@/lib/api-client"
 
 export function useWorkspaceOverlays() {
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false)
@@ -51,7 +51,7 @@ export function useWorkspaceOverlays() {
 
   const loadScrapeJobs = useCallback(async () => {
     try {
-      const response = await fetch("/api/scrape?limit=10")
+      const response = await fetch(buildApiPath("/api/scrape?limit=10"))
       const payload = await response.json()
       if (!payload.error) setScrapeJobs(payload.jobs || [])
     } catch {
@@ -71,7 +71,7 @@ export function useWorkspaceOverlays() {
 
     setScraping(true)
     try {
-      const response = await fetch("/api/scrape", {
+      const response = await fetch(buildApiPath("/api/scrape"), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -118,7 +118,7 @@ export function useWorkspaceOverlays() {
     formData.append("aiAutoScore", "true")
 
     try {
-      const response = await fetch("/api/upload", { method: "POST", body: formData })
+      const response = await fetch(buildApiPath("/api/upload"), { method: "POST", body: formData })
       const { data: result, text } = await readApiJsonOrText(response)
       if (!result) {
         throw new Error(`Upload API returned non-JSON (${response.status}). ${text?.slice(0, 120) || ""}`.trim())

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -1,6 +1,19 @@
+function getConfiguredBasePath(): string {
+  const rawBasePath = process.env.NEXT_PUBLIC_BASE_PATH?.trim() || ''
+  if (!rawBasePath || rawBasePath === '/') return ''
+
+  const withLeadingSlash = rawBasePath.startsWith('/') ? rawBasePath : `/${rawBasePath}`
+  return withLeadingSlash.replace(/\/+$/, '')
+}
+
+export function buildApiPath(path: string): string {
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`
+  return `${getConfiguredBasePath()}${normalizedPath}`
+}
+
 export async function readApiJsonOrText(response: Response): Promise<{ data: any | null; text: string | null }> {
-  const contentType = response.headers.get("content-type") || ""
-  if (contentType.includes("application/json")) {
+  const contentType = response.headers.get('content-type') || ''
+  if (contentType.includes('application/json')) {
     return { data: await response.json(), text: null }
   }
   return { data: null, text: await response.text() }


### PR DESCRIPTION
### Motivation
- Client-side calls to `/api/...` can break when the app is mounted under a path prefix, causing requests to resolve outside the app mount and return HTML 404s.
- Ensure upload, scrape and related client requests work correctly when `NEXT_PUBLIC_BASE_PATH` is configured.

### Description
- Added `buildApiPath()` in `src/lib/api-client.ts` to prepend a normalized `NEXT_PUBLIC_BASE_PATH` to API routes.
- Replaced hardcoded client fetches with `buildApiPath(...)` in `src/components/app/use-workspace-overlays.ts` for scrape list, scrape submit, and CSV upload POST requests.
- Updated the uploads history request in `src/app/page.tsx` to use `buildApiPath('/api/upload?limit=100')` and imported the helper where needed.

### Testing
- Ran `bun run lint` and the lint step completed successfully.
- Ran `bun run test` (Vitest) and the test suite passed (all tests succeeded according to the test run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6d7835090832a83b3b0182aed64af)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make client API calls base-path aware so upload and scrape requests work when the app is mounted under a path prefix. Honors `NEXT_PUBLIC_BASE_PATH` to prevent 404s from resolving outside the app.

- **Bug Fixes**
  - Added `buildApiPath()` to prepend a normalized `NEXT_PUBLIC_BASE_PATH` to API routes.
  - Updated scrape list/submit and CSV upload fetches in `src/components/app/use-workspace-overlays.ts` to use `buildApiPath()`.
  - Switched uploads history fetch in `src/app/page.tsx` to `buildApiPath('/api/upload?limit=100')`.

- **Migration**
  - If hosting under a subpath, set `NEXT_PUBLIC_BASE_PATH` (e.g., `/myapp`). No change needed for root deployments.

<sup>Written for commit 9c49ec20ed9fd65067cf31b62786e642d60f6689. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

