### PR TITLE
feat: add forgot password / reset password flow

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -70,8 +70,9 @@ model User {
   teamMember     TeamMember?
   assignments    LeadAssignment[]
   teamActivities TeamActivity[]
-  sessions       UserSession[]
-  aiProfile      UserAIProfile?
+  sessions            UserSession[]
+  aiProfile           UserAIProfile?
+  passwordResetTokens PasswordResetToken[]
 }
 
 // ============================================
@@ -1184,4 +1185,17 @@ model ScrapingSourcePerformance {
   @@unique([organizationId, sourceDomain])
   @@index([organizationId])
   @@index([conversionRate])
+}
+
+model PasswordResetToken {
+  id        String    @id @default(cuid())
+  userId    String
+  token     String    @unique
+  expiresAt DateTime
+  usedAt    DateTime?
+  createdAt DateTime  @default(now())
+  user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([token])
+  @@index([userId])
 }

--- a/src/app/api/auth/forgot-password/route.ts
+++ b/src/app/api/auth/forgot-password/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { randomBytes } from 'node:crypto'
+import { z } from 'zod'
+import { db } from '@/lib/db'
+import { enforceRateLimit } from '@/lib/rate-limit'
+import { parseJsonBody } from '@/lib/validation'
+import { enforceSameOrigin } from '@/lib/security'
+
+const schema = z.object({
+  email: z.string().email(),
+})
+
+export async function POST(request: NextRequest) {
+  try {
+    const csrfBlocked = enforceSameOrigin(request)
+    if (csrfBlocked) return csrfBlocked
+
+    const parsed = await parseJsonBody(request, schema)
+    if (!parsed.success) return parsed.response
+
+    const email = parsed.data.email.trim().toLowerCase()
+
+    const limited = enforceRateLimit(request, {
+      key: `forgot-password:${email}`,
+      limit: 3,
+      windowMs: 15 * 60_000,
+    })
+    if (limited) return limited
+
+    const user = await db.user.findUnique({
+      where: { email },
+      select: { id: true, email: true },
+    })
+
+    // Always return success to prevent email enumeration
+    if (!user) {
+      return NextResponse.json({ success: true, token: null })
+    }
+
+    // Expire any existing unused tokens for this user
+    await db.passwordResetToken.updateMany({
+      where: { userId: user.id, usedAt: null, expiresAt: { gt: new Date() } },
+      data: { expiresAt: new Date() },
+    })
+
+    const token = randomBytes(32).toString('hex')
+    const expiresAt = new Date(Date.now() + 60 * 60 * 1000) // 1 hour
+
+    await db.passwordResetToken.create({
+      data: {
+        userId: user.id,
+        token,
+        expiresAt,
+      },
+    })
+
+    return NextResponse.json({ success: true, token })
+  } catch (error) {
+    console.error('Forgot password error:', error)
+    return NextResponse.json({ error: 'Failed to process request' }, { status: 500 })
+  }
+}

--- a/src/app/api/auth/reset-password/route.ts
+++ b/src/app/api/auth/reset-password/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { db } from '@/lib/db'
+import { hashPassword } from '@/lib/auth'
+import { enforceRateLimit } from '@/lib/rate-limit'
+import { parseJsonBody } from '@/lib/validation'
+import { enforceSameOrigin } from '@/lib/security'
+
+const schema = z.object({
+  token: z.string().min(1),
+  password: z.string().min(8).max(200),
+})
+
+export async function POST(request: NextRequest) {
+  try {
+    const csrfBlocked = enforceSameOrigin(request)
+    if (csrfBlocked) return csrfBlocked
+
+    const limited = enforceRateLimit(request, {
+      key: 'reset-password',
+      limit: 10,
+      windowMs: 15 * 60_000,
+    })
+    if (limited) return limited
+
+    const parsed = await parseJsonBody(request, schema)
+    if (!parsed.success) return parsed.response
+
+    const { token, password } = parsed.data
+
+    const resetToken = await db.passwordResetToken.findUnique({
+      where: { token },
+      include: { user: { select: { id: true } } },
+    })
+
+    if (!resetToken) {
+      return NextResponse.json({ error: 'Invalid or expired reset token.' }, { status: 400 })
+    }
+
+    if (resetToken.usedAt) {
+      return NextResponse.json({ error: 'This reset token has already been used.' }, { status: 400 })
+    }
+
+    if (resetToken.expiresAt < new Date()) {
+      return NextResponse.json({ error: 'This reset token has expired. Please request a new one.' }, { status: 400 })
+    }
+
+    const passwordHash = hashPassword(password)
+
+    await db.$transaction(async (tx) => {
+      // Update password
+      await tx.user.update({
+        where: { id: resetToken.userId },
+        data: { passwordHash },
+      })
+
+      // Mark token as used
+      await tx.passwordResetToken.update({
+        where: { id: resetToken.id },
+        data: { usedAt: new Date() },
+      })
+
+      // Invalidate all active sessions
+      await tx.userSession.updateMany({
+        where: { userId: resetToken.userId, isActive: true },
+        data: { isActive: false },
+      })
+    })
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error('Reset password error:', error)
+    return NextResponse.json({ error: 'Failed to reset password' }, { status: 500 })
+  }
+}

--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -9,21 +9,36 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 
+type Mode = 'login' | 'signup' | 'forgot' | 'reset'
+
 export default function AuthPage() {
   const router = useRouter()
-  const [mode, setMode] = useState<'login' | 'signup'>('login')
+  const [mode, setMode] = useState<Mode>('login')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+
+  // Login
   const [loginEmail, setLoginEmail] = useState('')
   const [loginPassword, setLoginPassword] = useState('')
+
+  // Signup
   const [signupName, setSignupName] = useState('')
   const [signupEmail, setSignupEmail] = useState('')
   const [signupPassword, setSignupPassword] = useState('')
   const [organizationName, setOrganizationName] = useState('')
 
+  // Forgot password
+  const [forgotEmail, setForgotEmail] = useState('')
+  const [resetTokenDisplay, setResetTokenDisplay] = useState<string | null>(null)
+
+  // Reset password
+  const [resetToken, setResetToken] = useState('')
+  const [newPassword, setNewPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+
   useEffect(() => {
     let cancelled = false
-
     ;(async () => {
       try {
         const session = await getSession()
@@ -32,44 +47,36 @@ export default function AuthPage() {
           router.refresh()
         }
       } catch {
-        // Stay on auth page when session lookup fails.
+        // Stay on auth page
       }
     })()
-
-    return () => {
-      cancelled = true
-    }
+    return () => { cancelled = true }
   }, [router])
 
-  const submit = async () => {
+  const switchMode = (next: Mode) => {
+    setError(null)
+    setSuccess(null)
+    setResetTokenDisplay(null)
+    setMode(next)
+  }
+
+  const handleLoginSignup = async () => {
     setLoading(true)
     setError(null)
     try {
       if (mode === 'signup') {
-        const signupRes = await fetch('/api/auth/signup', {
+        const res = await fetch('/api/auth/signup', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            name: signupName,
-            email: signupEmail,
-            password: signupPassword,
-            organizationName,
-          }),
+          body: JSON.stringify({ name: signupName, email: signupEmail, password: signupPassword, organizationName }),
         })
-        const signupData = await signupRes.json()
-        if (!signupRes.ok || signupData.error) {
-          throw new Error(signupData.error || 'Authentication failed')
-        }
+        const data = await res.json()
+        if (!res.ok || data.error) throw new Error(data.error || 'Signup failed')
       }
 
       const email = mode === 'login' ? loginEmail : signupEmail
       const password = mode === 'login' ? loginPassword : signupPassword
-      const result = await signIn('credentials', {
-        redirect: false,
-        email,
-        password,
-        callbackUrl: '/',
-      })
+      const result = await signIn('credentials', { redirect: false, email, password, callbackUrl: '/' })
 
       if (!result || result.error) {
         throw new Error(mode === 'login' ? 'Invalid email or password.' : 'Authentication failed')
@@ -85,53 +92,195 @@ export default function AuthPage() {
     }
   }
 
+  const handleForgotPassword = async () => {
+    setLoading(true)
+    setError(null)
+    setResetTokenDisplay(null)
+    try {
+      const res = await fetch('/api/auth/forgot-password', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: forgotEmail }),
+      })
+      const data = await res.json()
+      if (!res.ok || data.error) throw new Error(data.error || 'Request failed')
+      if (data.token) {
+        setResetTokenDisplay(data.token)
+      } else {
+        setSuccess('If that email exists, a reset token has been generated. Contact your admin.')
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Request failed')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleResetPassword = async () => {
+    setLoading(true)
+    setError(null)
+    if (newPassword !== confirmPassword) {
+      setError('Passwords do not match.')
+      setLoading(false)
+      return
+    }
+    try {
+      const res = await fetch('/api/auth/reset-password', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token: resetToken.trim(), password: newPassword }),
+      })
+      const data = await res.json()
+      if (!res.ok || data.error) throw new Error(data.error || 'Reset failed')
+      setSuccess('Password reset successfully. You can now sign in.')
+      switchMode('login')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Reset failed')
+    } finally {
+      setLoading(false)
+    }
+  }
+
   return (
     <main className="min-h-screen bg-[#EFF4FB] text-foreground">
       <div className="mx-auto flex min-h-screen max-w-xl items-center justify-center px-6 py-16">
         <Card className="w-full border-[#D7DFEA] bg-white shadow-sm">
           <CardHeader>
             <CardTitle className="text-2xl font-semibold text-black">Insurafuze CRM</CardTitle>
-            <CardDescription>Sign in to your workspace or create a new organization.</CardDescription>
+            <CardDescription>
+              {mode === 'forgot' && 'Enter your email to get a password reset token.'}
+              {mode === 'reset' && 'Enter your reset token and choose a new password.'}
+              {(mode === 'login' || mode === 'signup') && 'Sign in to your workspace or create a new organization.'}
+            </CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
-            <Tabs value={mode} onValueChange={(value) => setMode(value as 'login' | 'signup')}>
-              <TabsList className="grid w-full grid-cols-2 bg-[#EEF2F7]">
-                <TabsTrigger value="login">Sign In</TabsTrigger>
-                <TabsTrigger value="signup">Create Account</TabsTrigger>
-              </TabsList>
-              <TabsContent value="login" className="space-y-4 mt-4">
+
+            {/* LOGIN / SIGNUP */}
+            {(mode === 'login' || mode === 'signup') && (
+              <>
+                <Tabs value={mode} onValueChange={(v) => switchMode(v as Mode)}>
+                  <TabsList className="grid w-full grid-cols-2 bg-[#EEF2F7]">
+                    <TabsTrigger value="login">Sign In</TabsTrigger>
+                    <TabsTrigger value="signup">Create Account</TabsTrigger>
+                  </TabsList>
+                  <TabsContent value="login" className="space-y-4 mt-4">
+                    <div>
+                      <Label>Email</Label>
+                      <Input className="mt-1" type="email" value={loginEmail} onChange={(e) => setLoginEmail(e.target.value)} onKeyDown={(e) => e.key === 'Enter' && void handleLoginSignup()} />
+                    </div>
+                    <div>
+                      <Label>Password</Label>
+                      <Input className="mt-1" type="password" value={loginPassword} onChange={(e) => setLoginPassword(e.target.value)} onKeyDown={(e) => e.key === 'Enter' && void handleLoginSignup()} />
+                    </div>
+                    <button
+                      type="button"
+                      className="text-sm text-[#2563EB] hover:underline"
+                      onClick={() => switchMode('forgot')}
+                    >
+                      Forgot password?
+                    </button>
+                  </TabsContent>
+                  <TabsContent value="signup" className="space-y-4 mt-4">
+                    <div>
+                      <Label>Your name</Label>
+                      <Input className="mt-1" value={signupName} onChange={(e) => setSignupName(e.target.value)} />
+                    </div>
+                    <div>
+                      <Label>Organization name</Label>
+                      <Input className="mt-1" value={organizationName} onChange={(e) => setOrganizationName(e.target.value)} />
+                    </div>
+                    <div>
+                      <Label>Email</Label>
+                      <Input className="mt-1" type="email" value={signupEmail} onChange={(e) => setSignupEmail(e.target.value)} />
+                    </div>
+                    <div>
+                      <Label>Password</Label>
+                      <Input className="mt-1" type="password" value={signupPassword} onChange={(e) => setSignupPassword(e.target.value)} />
+                    </div>
+                  </TabsContent>
+                </Tabs>
+                {success && <p className="text-sm text-emerald-600">{success}</p>}
+                {error && <p className="text-sm text-red-600">{error}</p>}
+                <Button className="btn-gold w-full" onClick={() => void handleLoginSignup()} disabled={loading}>
+                  {loading ? 'Working...' : mode === 'login' ? 'Sign In' : 'Create Workspace'}
+                </Button>
+                <p className="text-center text-sm text-gray-500">
+                  Have a reset token?{' '}
+                  <button type="button" className="text-[#2563EB] hover:underline" onClick={() => switchMode('reset')}>
+                    Reset password
+                  </button>
+                </p>
+              </>
+            )}
+
+            {/* FORGOT PASSWORD */}
+            {mode === 'forgot' && (
+              <>
                 <div>
-                  <Label>Email</Label>
-                  <Input className="mt-1" value={loginEmail} onChange={(e) => setLoginEmail(e.target.value)} />
+                  <Label>Email address</Label>
+                  <Input className="mt-1" type="email" value={forgotEmail} onChange={(e) => setForgotEmail(e.target.value)} onKeyDown={(e) => e.key === 'Enter' && void handleForgotPassword()} />
+                </div>
+                {error && <p className="text-sm text-red-600">{error}</p>}
+                {success && <p className="text-sm text-emerald-600">{success}</p>}
+                {resetTokenDisplay && (
+                  <div className="rounded-lg border border-[#2563EB]/30 bg-[#2563EB]/5 p-4 space-y-2">
+                    <p className="text-sm font-medium text-black">Your reset token (expires in 1 hour):</p>
+                    <div className="flex items-center gap-2">
+                      <code className="flex-1 break-all rounded bg-[#EEF2F7] px-3 py-2 text-xs font-mono text-black">
+                        {resetTokenDisplay}
+                      </code>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="shrink-0 border-[#D7DFEA]"
+                        onClick={() => void navigator.clipboard.writeText(resetTokenDisplay)}
+                      >
+                        Copy
+                      </Button>
+                    </div>
+                    <p className="text-xs text-gray-500">Copy this token, then use it below to set a new password.</p>
+                    <Button className="btn-gold w-full mt-2" onClick={() => { setResetToken(resetTokenDisplay); switchMode('reset') }}>
+                      Use this token →
+                    </Button>
+                  </div>
+                )}
+                {!resetTokenDisplay && (
+                  <Button className="btn-gold w-full" onClick={() => void handleForgotPassword()} disabled={loading}>
+                    {loading ? 'Working...' : 'Get Reset Token'}
+                  </Button>
+                )}
+                <button type="button" className="w-full text-center text-sm text-[#2563EB] hover:underline" onClick={() => switchMode('login')}>
+                  ← Back to sign in
+                </button>
+              </>
+            )}
+
+            {/* RESET PASSWORD */}
+            {mode === 'reset' && (
+              <>
+                <div>
+                  <Label>Reset token</Label>
+                  <Input className="mt-1 font-mono text-sm" value={resetToken} onChange={(e) => setResetToken(e.target.value)} placeholder="Paste your reset token" />
                 </div>
                 <div>
-                  <Label>Password</Label>
-                  <Input className="mt-1" type="password" value={loginPassword} onChange={(e) => setLoginPassword(e.target.value)} />
-                </div>
-              </TabsContent>
-              <TabsContent value="signup" className="space-y-4 mt-4">
-                <div>
-                  <Label>Your name</Label>
-                  <Input className="mt-1" value={signupName} onChange={(e) => setSignupName(e.target.value)} />
+                  <Label>New password</Label>
+                  <Input className="mt-1" type="password" value={newPassword} onChange={(e) => setNewPassword(e.target.value)} />
                 </div>
                 <div>
-                  <Label>Organization name</Label>
-                  <Input className="mt-1" value={organizationName} onChange={(e) => setOrganizationName(e.target.value)} />
+                  <Label>Confirm new password</Label>
+                  <Input className="mt-1" type="password" value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} onKeyDown={(e) => e.key === 'Enter' && void handleResetPassword()} />
                 </div>
-                <div>
-                  <Label>Email</Label>
-                  <Input className="mt-1" value={signupEmail} onChange={(e) => setSignupEmail(e.target.value)} />
-                </div>
-                <div>
-                  <Label>Password</Label>
-                  <Input className="mt-1" type="password" value={signupPassword} onChange={(e) => setSignupPassword(e.target.value)} />
-                </div>
-              </TabsContent>
-            </Tabs>
-            {error ? <p className="text-sm text-red-600">{error}</p> : null}
-            <Button className="btn-gold w-full" onClick={() => void submit()} disabled={loading}>
-              {loading ? 'Working...' : mode === 'login' ? 'Sign In' : 'Create Workspace'}
-            </Button>
+                {error && <p className="text-sm text-red-600">{error}</p>}
+                {success && <p className="text-sm text-emerald-600">{success}</p>}
+                <Button className="btn-gold w-full" onClick={() => void handleResetPassword()} disabled={loading}>
+                  {loading ? 'Resetting...' : 'Reset Password'}
+                </Button>
+                <button type="button" className="w-full text-center text-sm text-[#2563EB] hover:underline" onClick={() => switchMode('forgot')}>
+                  ← Get a new token
+                </button>
+              </>
+            )}
+
           </CardContent>
         </Card>
       </div>


### PR DESCRIPTION
## What this adds

- **Forgot password** flow on the auth page — user enters email, gets a reset token displayed on screen (no email required)
- **Reset password** flow — user enters token + new password, password updated, all sessions invalidated
- Token expires in 1 hour, single-use only
- Rate limited (3 requests per 15 min per email)
- New `PasswordResetToken` model added to schema
- Schema pushed to Supabase

## Files changed
- `prisma/schema.prisma` — added PasswordResetToken model
- `src/app/auth/page.tsx` — full forgot/reset UI added
- `src/app/api/auth/forgot-password/route.ts` — new route
- `src/app/api/auth/reset-password/route.ts` — new route

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add token-based forgot/reset password flow to let users recover accounts securely. Adds UI, API routes, and a new Prisma model with rate limits and session invalidation.

- **New Features**
  - Added `PasswordResetToken` model (single-use, 1h expiry; indexed by `token` and `userId`).
  - New routes:
    - `POST /api/auth/forgot-password` — issues token, rate-limited (3/15m per email), avoids email enumeration.
    - `POST /api/auth/reset-password` — validates token, updates password, marks token used, invalidates all sessions (10/15m limit).
  - Updated auth page with “Forgot password” and “Reset password” tabs; shows token in UI for now with copy action and basic validation.
  - Security: same-origin check on both routes; existing unused tokens are expired when a new one is issued.

- **Migration**
  - Apply Prisma schema update to add `PasswordResetToken` (e.g., `prisma migrate deploy` or `prisma db push` to Supabase).

<sup>Written for commit 2793180168bfca589b24a5fbf0dab2d7f0b0a07b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

