### PR TITLE
feat: premium King CRM landing page

### DIFF
--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -4,12 +4,17 @@ import { useRouter } from 'next/navigation'
 import { useEffect, useState } from 'react'
 import { getSession, signIn } from 'next-auth/react'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 
 type Mode = 'login' | 'signup' | 'forgot' | 'reset'
+
+const FEATURES = [
+  { icon: '👥', title: 'Lead Management', desc: 'Track, score, and convert leads faster than ever.' },
+  { icon: '📊', title: 'Pipeline Analytics', desc: 'Real-time insights on every stage of your sales funnel.' },
+  { icon: '⚡', title: 'Automated Sequences', desc: 'Follow-ups that run while you close deals.' },
+  { icon: '🏆', title: 'Team Performance', desc: 'Leaderboards, quotas, and coaching built in.' },
+]
 
 export default function AuthPage() {
   const router = useRouter()
@@ -28,11 +33,11 @@ export default function AuthPage() {
   const [signupPassword, setSignupPassword] = useState('')
   const [organizationName, setOrganizationName] = useState('')
 
-  // Forgot password
+  // Forgot
   const [forgotEmail, setForgotEmail] = useState('')
   const [resetTokenDisplay, setResetTokenDisplay] = useState<string | null>(null)
 
-  // Reset password
+  // Reset
   const [resetToken, setResetToken] = useState('')
   const [newPassword, setNewPassword] = useState('')
   const [confirmPassword, setConfirmPassword] = useState('')
@@ -46,23 +51,17 @@ export default function AuthPage() {
           router.replace(session.user.mustChangePassword ? '/auth/password' : '/')
           router.refresh()
         }
-      } catch {
-        // Stay on auth page
-      }
+      } catch { /* stay on page */ }
     })()
     return () => { cancelled = true }
   }, [router])
 
   const switchMode = (next: Mode) => {
-    setError(null)
-    setSuccess(null)
-    setResetTokenDisplay(null)
-    setMode(next)
+    setError(null); setSuccess(null); setResetTokenDisplay(null); setMode(next)
   }
 
   const handleLoginSignup = async () => {
-    setLoading(true)
-    setError(null)
+    setLoading(true); setError(null)
     try {
       if (mode === 'signup') {
         const res = await fetch('/api/auth/signup', {
@@ -73,29 +72,20 @@ export default function AuthPage() {
         const data = await res.json()
         if (!res.ok || data.error) throw new Error(data.error || 'Signup failed')
       }
-
       const email = mode === 'login' ? loginEmail : signupEmail
       const password = mode === 'login' ? loginPassword : signupPassword
       const result = await signIn('credentials', { redirect: false, email, password, callbackUrl: '/' })
-
-      if (!result || result.error) {
-        throw new Error(mode === 'login' ? 'Invalid email or password.' : 'Authentication failed')
-      }
-
+      if (!result || result.error) throw new Error(mode === 'login' ? 'Invalid email or password.' : 'Authentication failed')
       const session = await getSession()
       router.push(session?.user?.mustChangePassword ? '/auth/password' : '/')
       router.refresh()
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Authentication failed')
-    } finally {
-      setLoading(false)
-    }
+    } finally { setLoading(false) }
   }
 
   const handleForgotPassword = async () => {
-    setLoading(true)
-    setError(null)
-    setResetTokenDisplay(null)
+    setLoading(true); setError(null); setResetTokenDisplay(null)
     try {
       const res = await fetch('/api/auth/forgot-password', {
         method: 'POST',
@@ -104,26 +94,16 @@ export default function AuthPage() {
       })
       const data = await res.json()
       if (!res.ok || data.error) throw new Error(data.error || 'Request failed')
-      if (data.token) {
-        setResetTokenDisplay(data.token)
-      } else {
-        setSuccess('If that email exists, a reset token has been generated. Contact your admin.')
-      }
+      if (data.token) { setResetTokenDisplay(data.token) }
+      else { setSuccess('If that email exists, contact your admin for the reset token.') }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Request failed')
-    } finally {
-      setLoading(false)
-    }
+    } finally { setLoading(false) }
   }
 
   const handleResetPassword = async () => {
-    setLoading(true)
-    setError(null)
-    if (newPassword !== confirmPassword) {
-      setError('Passwords do not match.')
-      setLoading(false)
-      return
-    }
+    setLoading(true); setError(null)
+    if (newPassword !== confirmPassword) { setError('Passwords do not match.'); setLoading(false); return }
     try {
       const res = await fetch('/api/auth/reset-password', {
         method: 'POST',
@@ -132,157 +112,302 @@ export default function AuthPage() {
       })
       const data = await res.json()
       if (!res.ok || data.error) throw new Error(data.error || 'Reset failed')
-      setSuccess('Password reset successfully. You can now sign in.')
+      setSuccess('Password reset successfully.')
       switchMode('login')
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Reset failed')
-    } finally {
-      setLoading(false)
-    }
+    } finally { setLoading(false) }
   }
 
   return (
-    <main className="min-h-screen bg-[#EFF4FB] text-foreground">
-      <div className="mx-auto flex min-h-screen max-w-xl items-center justify-center px-6 py-16">
-        <Card className="w-full border-[#D7DFEA] bg-white shadow-sm">
-          <CardHeader>
-            <CardTitle className="text-2xl font-semibold text-black">Insurafuze CRM</CardTitle>
-            <CardDescription>
-              {mode === 'forgot' && 'Enter your email to get a password reset token.'}
-              {mode === 'reset' && 'Enter your reset token and choose a new password.'}
-              {(mode === 'login' || mode === 'signup') && 'Sign in to your workspace or create a new organization.'}
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
+    <main className="min-h-screen bg-[#080C14] text-white overflow-hidden relative">
 
-            {/* LOGIN / SIGNUP */}
+      {/* Background glow effects */}
+      <div className="pointer-events-none absolute inset-0 overflow-hidden">
+        <div className="absolute -top-40 -left-40 w-[600px] h-[600px] rounded-full bg-[#2563EB] opacity-10 blur-[120px]" />
+        <div className="absolute -bottom-40 -right-40 w-[600px] h-[600px] rounded-full bg-[#14B8A6] opacity-10 blur-[120px]" />
+        <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[800px] h-[800px] rounded-full bg-[#0EA5E9] opacity-5 blur-[160px]" />
+      </div>
+
+      <div className="relative z-10 flex min-h-screen flex-col lg:flex-row">
+
+        {/* LEFT — Hero */}
+        <div className="flex flex-1 flex-col justify-center px-8 py-16 lg:px-16 lg:py-24 xl:px-24">
+          {/* Logo / Brand */}
+          <div className="mb-12">
+            <div className="inline-flex items-center gap-3 mb-6">
+              <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-[#2563EB] to-[#14B8A6] flex items-center justify-center shadow-lg shadow-blue-500/30">
+                <span className="text-white font-black text-lg">K</span>
+              </div>
+              <span className="text-white/60 text-sm font-semibold tracking-[0.2em] uppercase">King CRM</span>
+            </div>
+            <h1 className="text-5xl lg:text-6xl xl:text-7xl font-black leading-[1.05] tracking-tight mb-6">
+              <span className="text-white">Close More.</span>
+              <br />
+              <span className="bg-gradient-to-r from-[#2563EB] via-[#0EA5E9] to-[#14B8A6] bg-clip-text text-transparent">
+                Work Less.
+              </span>
+              <br />
+              <span className="text-white">Win Always.</span>
+            </h1>
+            <p className="text-white/50 text-lg lg:text-xl max-w-lg leading-relaxed">
+              The CRM built for insurance pros who are serious about growth. Leads, pipelines, automation — all in one place.
+            </p>
+          </div>
+
+          {/* Feature grid */}
+          <div className="grid grid-cols-2 gap-4 max-w-lg">
+            {FEATURES.map((f) => (
+              <div
+                key={f.title}
+                className="rounded-2xl border border-white/[0.06] bg-white/[0.04] backdrop-blur-sm p-4 hover:bg-white/[0.08] hover:border-white/10 transition-all duration-200"
+              >
+                <div className="text-2xl mb-2">{f.icon}</div>
+                <div className="text-white font-semibold text-sm mb-1">{f.title}</div>
+                <div className="text-white/40 text-xs leading-relaxed">{f.desc}</div>
+              </div>
+            ))}
+          </div>
+
+          {/* Social proof */}
+          <div className="mt-10 flex items-center gap-4">
+            <div className="flex -space-x-2">
+              {['#2563EB','#0EA5E9','#14B8A6','#06B6D4'].map((c, i) => (
+                <div key={i} className="w-8 h-8 rounded-full border-2 border-[#080C14] flex items-center justify-center text-white text-xs font-bold" style={{background: c}}>
+                  {['J','M','S','A'][i]}
+                </div>
+              ))}
+            </div>
+            <p className="text-white/40 text-sm">
+              <span className="text-white/70 font-semibold">Insurance teams</span> trust King CRM to close more deals
+            </p>
+          </div>
+        </div>
+
+        {/* RIGHT — Auth Form */}
+        <div className="flex items-center justify-center px-6 py-12 lg:w-[480px] xl:w-[520px] lg:border-l border-white/[0.06]">
+          <div className="w-full max-w-sm">
+
+            {/* Form tabs for login/signup */}
             {(mode === 'login' || mode === 'signup') && (
               <>
-                <Tabs value={mode} onValueChange={(v) => switchMode(v as Mode)}>
-                  <TabsList className="grid w-full grid-cols-2 bg-[#EEF2F7]">
-                    <TabsTrigger value="login">Sign In</TabsTrigger>
-                    <TabsTrigger value="signup">Create Account</TabsTrigger>
-                  </TabsList>
-                  <TabsContent value="login" className="space-y-4 mt-4">
-                    <div>
-                      <Label>Email</Label>
-                      <Input className="mt-1" type="email" value={loginEmail} onChange={(e) => setLoginEmail(e.target.value)} onKeyDown={(e) => e.key === 'Enter' && void handleLoginSignup()} />
-                    </div>
-                    <div>
-                      <Label>Password</Label>
-                      <Input className="mt-1" type="password" value={loginPassword} onChange={(e) => setLoginPassword(e.target.value)} onKeyDown={(e) => e.key === 'Enter' && void handleLoginSignup()} />
-                    </div>
-                    <button
-                      type="button"
-                      className="text-sm text-[#2563EB] hover:underline"
-                      onClick={() => switchMode('forgot')}
-                    >
-                      Forgot password?
-                    </button>
-                  </TabsContent>
-                  <TabsContent value="signup" className="space-y-4 mt-4">
-                    <div>
-                      <Label>Your name</Label>
-                      <Input className="mt-1" value={signupName} onChange={(e) => setSignupName(e.target.value)} />
-                    </div>
-                    <div>
-                      <Label>Organization name</Label>
-                      <Input className="mt-1" value={organizationName} onChange={(e) => setOrganizationName(e.target.value)} />
-                    </div>
-                    <div>
-                      <Label>Email</Label>
-                      <Input className="mt-1" type="email" value={signupEmail} onChange={(e) => setSignupEmail(e.target.value)} />
-                    </div>
-                    <div>
-                      <Label>Password</Label>
-                      <Input className="mt-1" type="password" value={signupPassword} onChange={(e) => setSignupPassword(e.target.value)} />
-                    </div>
-                  </TabsContent>
-                </Tabs>
-                {success && <p className="text-sm text-emerald-600">{success}</p>}
-                {error && <p className="text-sm text-red-600">{error}</p>}
-                <Button className="btn-gold w-full" onClick={() => void handleLoginSignup()} disabled={loading}>
-                  {loading ? 'Working...' : mode === 'login' ? 'Sign In' : 'Create Workspace'}
-                </Button>
-                <p className="text-center text-sm text-gray-500">
-                  Have a reset token?{' '}
-                  <button type="button" className="text-[#2563EB] hover:underline" onClick={() => switchMode('reset')}>
-                    Reset password
+                <div className="mb-8">
+                  <h2 className="text-2xl font-bold text-white mb-1">
+                    {mode === 'login' ? 'Welcome back' : 'Create your workspace'}
+                  </h2>
+                  <p className="text-white/40 text-sm">
+                    {mode === 'login' ? "Sign in to your King CRM account." : "Get started in under 2 minutes."}
+                  </p>
+                </div>
+
+                {/* Tab switcher */}
+                <div className="flex rounded-xl border border-white/[0.08] bg-white/[0.04] p-1 mb-6">
+                  <button
+                    onClick={() => switchMode('login')}
+                    className={`flex-1 py-2 px-4 rounded-lg text-sm font-semibold transition-all ${
+                      mode === 'login'
+                        ? 'bg-gradient-to-r from-[#2563EB] to-[#0EA5E9] text-white shadow-lg shadow-blue-500/20'
+                        : 'text-white/40 hover:text-white/70'
+                    }`}
+                  >
+                    Sign In
                   </button>
-                </p>
+                  <button
+                    onClick={() => switchMode('signup')}
+                    className={`flex-1 py-2 px-4 rounded-lg text-sm font-semibold transition-all ${
+                      mode === 'signup'
+                        ? 'bg-gradient-to-r from-[#2563EB] to-[#0EA5E9] text-white shadow-lg shadow-blue-500/20'
+                        : 'text-white/40 hover:text-white/70'
+                    }`}
+                  >
+                    Create Account
+                  </button>
+                </div>
+
+                <div className="space-y-4">
+                  {mode === 'signup' && (
+                    <>
+                      <div>
+                        <Label className="text-white/60 text-xs font-semibold uppercase tracking-wider mb-1.5 block">Your name</Label>
+                        <Input
+                          className="bg-white/[0.06] border-white/10 text-white placeholder:text-white/20 focus:border-[#2563EB] focus:ring-[#2563EB]/20 h-11 rounded-xl"
+                          placeholder="Brady Wilson"
+                          value={signupName}
+                          onChange={(e) => setSignupName(e.target.value)}
+                        />
+                      </div>
+                      <div>
+                        <Label className="text-white/60 text-xs font-semibold uppercase tracking-wider mb-1.5 block">Organization</Label>
+                        <Input
+                          className="bg-white/[0.06] border-white/10 text-white placeholder:text-white/20 focus:border-[#2563EB] focus:ring-[#2563EB]/20 h-11 rounded-xl"
+                          placeholder="Brighter Health Solutions"
+                          value={organizationName}
+                          onChange={(e) => setOrganizationName(e.target.value)}
+                        />
+                      </div>
+                    </>
+                  )}
+                  <div>
+                    <Label className="text-white/60 text-xs font-semibold uppercase tracking-wider mb-1.5 block">Email</Label>
+                    <Input
+                      type="email"
+                      className="bg-white/[0.06] border-white/10 text-white placeholder:text-white/20 focus:border-[#2563EB] focus:ring-[#2563EB]/20 h-11 rounded-xl"
+                      placeholder="you@company.com"
+                      value={mode === 'login' ? loginEmail : signupEmail}
+                      onChange={(e) => mode === 'login' ? setLoginEmail(e.target.value) : setSignupEmail(e.target.value)}
+                      onKeyDown={(e) => e.key === 'Enter' && void handleLoginSignup()}
+                    />
+                  </div>
+                  <div>
+                    <Label className="text-white/60 text-xs font-semibold uppercase tracking-wider mb-1.5 block">Password</Label>
+                    <Input
+                      type="password"
+                      className="bg-white/[0.06] border-white/10 text-white placeholder:text-white/20 focus:border-[#2563EB] focus:ring-[#2563EB]/20 h-11 rounded-xl"
+                      placeholder="••••••••"
+                      value={mode === 'login' ? loginPassword : signupPassword}
+                      onChange={(e) => mode === 'login' ? setLoginPassword(e.target.value) : setSignupPassword(e.target.value)}
+                      onKeyDown={(e) => e.key === 'Enter' && void handleLoginSignup()}
+                    />
+                  </div>
+
+                  {mode === 'login' && (
+                    <div className="flex justify-end">
+                      <button type="button" onClick={() => switchMode('forgot')} className="text-xs text-[#0EA5E9] hover:text-[#2563EB] transition-colors">
+                        Forgot password?
+                      </button>
+                    </div>
+                  )}
+
+                  {error && (
+                    <div className="rounded-xl bg-red-500/10 border border-red-500/20 px-4 py-3 text-sm text-red-400">
+                      {error}
+                    </div>
+                  )}
+
+                  <button
+                    onClick={() => void handleLoginSignup()}
+                    disabled={loading}
+                    className="w-full h-11 rounded-xl bg-gradient-to-r from-[#2563EB] to-[#14B8A6] text-white font-semibold text-sm hover:opacity-90 hover:-translate-y-0.5 active:translate-y-0 transition-all duration-150 shadow-lg shadow-blue-500/25 disabled:opacity-50 disabled:cursor-not-allowed disabled:translate-y-0"
+                  >
+                    {loading ? 'Working...' : mode === 'login' ? 'Sign In →' : 'Create Workspace →'}
+                  </button>
+
+                  <p className="text-center text-xs text-white/30">
+                    Have a reset token?{' '}
+                    <button type="button" onClick={() => switchMode('reset')} className="text-[#0EA5E9] hover:text-white transition-colors">
+                      Reset password
+                    </button>
+                  </p>
+                </div>
               </>
             )}
 
             {/* FORGOT PASSWORD */}
             {mode === 'forgot' && (
               <>
-                <div>
-                  <Label>Email address</Label>
-                  <Input className="mt-1" type="email" value={forgotEmail} onChange={(e) => setForgotEmail(e.target.value)} onKeyDown={(e) => e.key === 'Enter' && void handleForgotPassword()} />
+                <div className="mb-8">
+                  <button onClick={() => switchMode('login')} className="text-white/40 hover:text-white text-sm mb-4 flex items-center gap-1 transition-colors">
+                    ← Back
+                  </button>
+                  <h2 className="text-2xl font-bold text-white mb-1">Reset your password</h2>
+                  <p className="text-white/40 text-sm">Enter your email to get a reset token.</p>
                 </div>
-                {error && <p className="text-sm text-red-600">{error}</p>}
-                {success && <p className="text-sm text-emerald-600">{success}</p>}
-                {resetTokenDisplay && (
-                  <div className="rounded-lg border border-[#2563EB]/30 bg-[#2563EB]/5 p-4 space-y-2">
-                    <p className="text-sm font-medium text-black">Your reset token (expires in 1 hour):</p>
-                    <div className="flex items-center gap-2">
-                      <code className="flex-1 break-all rounded bg-[#EEF2F7] px-3 py-2 text-xs font-mono text-black">
-                        {resetTokenDisplay}
-                      </code>
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        className="shrink-0 border-[#D7DFEA]"
-                        onClick={() => void navigator.clipboard.writeText(resetTokenDisplay)}
-                      >
-                        Copy
-                      </Button>
-                    </div>
-                    <p className="text-xs text-gray-500">Copy this token, then use it below to set a new password.</p>
-                    <Button className="btn-gold w-full mt-2" onClick={() => { setResetToken(resetTokenDisplay); switchMode('reset') }}>
-                      Use this token →
-                    </Button>
+                <div className="space-y-4">
+                  <div>
+                    <Label className="text-white/60 text-xs font-semibold uppercase tracking-wider mb-1.5 block">Email address</Label>
+                    <Input
+                      type="email"
+                      className="bg-white/[0.06] border-white/10 text-white placeholder:text-white/20 focus:border-[#2563EB] h-11 rounded-xl"
+                      placeholder="you@company.com"
+                      value={forgotEmail}
+                      onChange={(e) => setForgotEmail(e.target.value)}
+                      onKeyDown={(e) => e.key === 'Enter' && void handleForgotPassword()}
+                    />
                   </div>
-                )}
-                {!resetTokenDisplay && (
-                  <Button className="btn-gold w-full" onClick={() => void handleForgotPassword()} disabled={loading}>
-                    {loading ? 'Working...' : 'Get Reset Token'}
-                  </Button>
-                )}
-                <button type="button" className="w-full text-center text-sm text-[#2563EB] hover:underline" onClick={() => switchMode('login')}>
-                  ← Back to sign in
-                </button>
+                  {error && <div className="rounded-xl bg-red-500/10 border border-red-500/20 px-4 py-3 text-sm text-red-400">{error}</div>}
+                  {success && <div className="rounded-xl bg-emerald-500/10 border border-emerald-500/20 px-4 py-3 text-sm text-emerald-400">{success}</div>}
+                  {resetTokenDisplay && (
+                    <div className="rounded-xl border border-[#2563EB]/30 bg-[#2563EB]/10 p-4 space-y-3">
+                      <p className="text-sm font-semibold text-white">Your reset token (expires in 1 hour):</p>
+                      <div className="flex items-center gap-2">
+                        <code className="flex-1 break-all rounded-lg bg-white/[0.06] px-3 py-2 text-xs font-mono text-[#0EA5E9]">
+                          {resetTokenDisplay}
+                        </code>
+                        <button
+                          onClick={() => void navigator.clipboard.writeText(resetTokenDisplay)}
+                          className="shrink-0 px-3 py-2 rounded-lg border border-white/10 text-white/60 hover:text-white text-xs transition-colors"
+                        >
+                          Copy
+                        </button>
+                      </div>
+                      <button
+                        onClick={() => { setResetToken(resetTokenDisplay); switchMode('reset') }}
+                        className="w-full h-10 rounded-xl bg-gradient-to-r from-[#2563EB] to-[#14B8A6] text-white font-semibold text-sm hover:opacity-90 transition-all"
+                      >
+                        Use this token →
+                      </button>
+                    </div>
+                  )}
+                  {!resetTokenDisplay && (
+                    <button
+                      onClick={() => void handleForgotPassword()}
+                      disabled={loading}
+                      className="w-full h-11 rounded-xl bg-gradient-to-r from-[#2563EB] to-[#14B8A6] text-white font-semibold text-sm hover:opacity-90 transition-all shadow-lg shadow-blue-500/25 disabled:opacity-50"
+                    >
+                      {loading ? 'Working...' : 'Get Reset Token →'}
+                    </button>
+                  )}
+                </div>
               </>
             )}
 
             {/* RESET PASSWORD */}
             {mode === 'reset' && (
               <>
-                <div>
-                  <Label>Reset token</Label>
-                  <Input className="mt-1 font-mono text-sm" value={resetToken} onChange={(e) => setResetToken(e.target.value)} placeholder="Paste your reset token" />
+                <div className="mb-8">
+                  <button onClick={() => switchMode('forgot')} className="text-white/40 hover:text-white text-sm mb-4 flex items-center gap-1 transition-colors">
+                    ← Back
+                  </button>
+                  <h2 className="text-2xl font-bold text-white mb-1">Set new password</h2>
+                  <p className="text-white/40 text-sm">Enter your reset token and choose a new password.</p>
                 </div>
-                <div>
-                  <Label>New password</Label>
-                  <Input className="mt-1" type="password" value={newPassword} onChange={(e) => setNewPassword(e.target.value)} />
+                <div className="space-y-4">
+                  <div>
+                    <Label className="text-white/60 text-xs font-semibold uppercase tracking-wider mb-1.5 block">Reset token</Label>
+                    <Input
+                      className="bg-white/[0.06] border-white/10 text-white font-mono text-sm placeholder:text-white/20 focus:border-[#2563EB] h-11 rounded-xl"
+                      placeholder="Paste your reset token"
+                      value={resetToken}
+                      onChange={(e) => setResetToken(e.target.value)}
+                    />
+                  </div>
+                  <div>
+                    <Label className="text-white/60 text-xs font-semibold uppercase tracking-wider mb-1.5 block">New password</Label>
+                    <Input type="password" className="bg-white/[0.06] border-white/10 text-white placeholder:text-white/20 focus:border-[#2563EB] h-11 rounded-xl" placeholder="••••••••" value={newPassword} onChange={(e) => setNewPassword(e.target.value)} />
+                  </div>
+                  <div>
+                    <Label className="text-white/60 text-xs font-semibold uppercase tracking-wider mb-1.5 block">Confirm password</Label>
+                    <Input type="password" className="bg-white/[0.06] border-white/10 text-white placeholder:text-white/20 focus:border-[#2563EB] h-11 rounded-xl" placeholder="••••••••" value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} onKeyDown={(e) => e.key === 'Enter' && void handleResetPassword()} />
+                  </div>
+                  {error && <div className="rounded-xl bg-red-500/10 border border-red-500/20 px-4 py-3 text-sm text-red-400">{error}</div>}
+                  {success && <div className="rounded-xl bg-emerald-500/10 border border-emerald-500/20 px-4 py-3 text-sm text-emerald-400">{success}</div>}
+                  <button
+                    onClick={() => void handleResetPassword()}
+                    disabled={loading}
+                    className="w-full h-11 rounded-xl bg-gradient-to-r from-[#2563EB] to-[#14B8A6] text-white font-semibold text-sm hover:opacity-90 transition-all shadow-lg shadow-blue-500/25 disabled:opacity-50"
+                  >
+                    {loading ? 'Resetting...' : 'Reset Password →'}
+                  </button>
                 </div>
-                <div>
-                  <Label>Confirm new password</Label>
-                  <Input className="mt-1" type="password" value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} onKeyDown={(e) => e.key === 'Enter' && void handleResetPassword()} />
-                </div>
-                {error && <p className="text-sm text-red-600">{error}</p>}
-                {success && <p className="text-sm text-emerald-600">{success}</p>}
-                <Button className="btn-gold w-full" onClick={() => void handleResetPassword()} disabled={loading}>
-                  {loading ? 'Resetting...' : 'Reset Password'}
-                </Button>
-                <button type="button" className="w-full text-center text-sm text-[#2563EB] hover:underline" onClick={() => switchMode('forgot')}>
-                  ← Get a new token
-                </button>
               </>
             )}
 
-          </CardContent>
-        </Card>
+            {/* Footer */}
+            <p className="mt-8 text-center text-xs text-white/20">
+              © 2026 King CRM Hub · Built for insurance pros
+            </p>
+          </div>
+        </div>
       </div>
     </main>
   )

--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -3,16 +3,15 @@
 import { useRouter } from 'next/navigation'
 import { useEffect, useState } from 'react'
 import { getSession, signIn } from 'next-auth/react'
-import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 
 type Mode = 'login' | 'signup' | 'forgot' | 'reset'
 
 const FEATURES = [
-  { icon: '👥', title: 'Lead Management', desc: 'Track, score, and convert leads faster than ever.' },
-  { icon: '📊', title: 'Pipeline Analytics', desc: 'Real-time insights on every stage of your sales funnel.' },
-  { icon: '⚡', title: 'Automated Sequences', desc: 'Follow-ups that run while you close deals.' },
+  { icon: '👥', title: 'Lead Management', desc: 'Capture, score, and convert leads without lifting a finger.' },
+  { icon: '📊', title: 'Pipeline Analytics', desc: 'Real-time visibility on every deal, every stage.' },
+  { icon: '⚡', title: 'Automated Sequences', desc: 'Follow-ups that run while you close.' },
   { icon: '🏆', title: 'Team Performance', desc: 'Leaderboards, quotas, and coaching built in.' },
 ]
 
@@ -23,21 +22,14 @@ export default function AuthPage() {
   const [error, setError] = useState<string | null>(null)
   const [success, setSuccess] = useState<string | null>(null)
 
-  // Login
   const [loginEmail, setLoginEmail] = useState('')
   const [loginPassword, setLoginPassword] = useState('')
-
-  // Signup
   const [signupName, setSignupName] = useState('')
   const [signupEmail, setSignupEmail] = useState('')
   const [signupPassword, setSignupPassword] = useState('')
   const [organizationName, setOrganizationName] = useState('')
-
-  // Forgot
   const [forgotEmail, setForgotEmail] = useState('')
   const [resetTokenDisplay, setResetTokenDisplay] = useState<string | null>(null)
-
-  // Reset
   const [resetToken, setResetToken] = useState('')
   const [newPassword, setNewPassword] = useState('')
   const [confirmPassword, setConfirmPassword] = useState('')
@@ -51,7 +43,7 @@ export default function AuthPage() {
           router.replace(session.user.mustChangePassword ? '/auth/password' : '/')
           router.refresh()
         }
-      } catch { /* stay on page */ }
+      } catch { /* stay */ }
     })()
     return () => { cancelled = true }
   }, [router])
@@ -94,8 +86,8 @@ export default function AuthPage() {
       })
       const data = await res.json()
       if (!res.ok || data.error) throw new Error(data.error || 'Request failed')
-      if (data.token) { setResetTokenDisplay(data.token) }
-      else { setSuccess('If that email exists, contact your admin for the reset token.') }
+      if (data.token) setResetTokenDisplay(data.token)
+      else setSuccess('If that email exists, contact your admin for the reset token.')
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Request failed')
     } finally { setLoading(false) }
@@ -120,181 +112,147 @@ export default function AuthPage() {
   }
 
   return (
-    <main className="min-h-screen bg-[#080C14] text-white overflow-hidden relative">
+    <main className="min-h-screen overflow-hidden" style={{ background: '#fafaf8' }}>
 
-      {/* Background glow effects */}
-      <div className="pointer-events-none absolute inset-0 overflow-hidden">
-        <div className="absolute -top-40 -left-40 w-[600px] h-[600px] rounded-full bg-[#2563EB] opacity-10 blur-[120px]" />
-        <div className="absolute -bottom-40 -right-40 w-[600px] h-[600px] rounded-full bg-[#14B8A6] opacity-10 blur-[120px]" />
-        <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[800px] h-[800px] rounded-full bg-[#0EA5E9] opacity-5 blur-[160px]" />
-      </div>
+      {/* Top nav bar */}
+      <nav className="absolute top-0 left-0 right-0 z-20 flex items-center justify-between px-8 py-5">
+        <div className="flex items-center gap-2.5">
+          <div className="w-8 h-8 rounded-lg flex items-center justify-center font-black text-white text-sm shadow-md" style={{ background: 'linear-gradient(135deg, #557df5, #3a5fd9)' }}>K</div>
+          <span className="font-bold text-sm tracking-wide" style={{ color: '#1f2a36' }}>KING CRM HUB</span>
+        </div>
+        <div className="hidden md:flex items-center gap-6 text-sm font-medium" style={{ color: '#1f2a36', opacity: 0.5 }}>
+          <span>Features</span>
+          <span>Pricing</span>
+          <span>Support</span>
+        </div>
+      </nav>
 
-      <div className="relative z-10 flex min-h-screen flex-col lg:flex-row">
+      <div className="flex min-h-screen flex-col lg:flex-row">
 
         {/* LEFT — Hero */}
-        <div className="flex flex-1 flex-col justify-center px-8 py-16 lg:px-16 lg:py-24 xl:px-24">
-          {/* Logo / Brand */}
-          <div className="mb-12">
-            <div className="inline-flex items-center gap-3 mb-6">
-              <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-[#2563EB] to-[#14B8A6] flex items-center justify-center shadow-lg shadow-blue-500/30">
-                <span className="text-white font-black text-lg">K</span>
-              </div>
-              <span className="text-white/60 text-sm font-semibold tracking-[0.2em] uppercase">King CRM</span>
+        <div className="flex flex-1 flex-col justify-center px-8 pt-24 pb-16 lg:px-16 lg:py-0 xl:px-24 relative">
+
+          {/* Decorative soft blob */}
+          <div className="pointer-events-none absolute top-0 right-0 w-[500px] h-[500px] rounded-full opacity-40" style={{ background: 'radial-gradient(circle, #557df520 0%, transparent 70%)' }} />
+
+          <div className="max-w-xl relative">
+            {/* Badge */}
+            <div className="inline-flex items-center gap-2 rounded-full px-4 py-1.5 mb-8 text-xs font-semibold border" style={{ background: '#fcf8ec', borderColor: '#557df530', color: '#557df5' }}>
+              <span className="w-1.5 h-1.5 rounded-full inline-block" style={{ background: '#557df5' }} />
+              Built for Insurance Professionals
             </div>
-            <h1 className="text-5xl lg:text-6xl xl:text-7xl font-black leading-[1.05] tracking-tight mb-6">
-              <span className="text-white">Close More.</span>
-              <br />
-              <span className="bg-gradient-to-r from-[#2563EB] via-[#0EA5E9] to-[#14B8A6] bg-clip-text text-transparent">
-                Work Less.
-              </span>
-              <br />
-              <span className="text-white">Win Always.</span>
+
+            <h1 className="font-black leading-[1.08] tracking-tight mb-6" style={{ fontSize: 'clamp(2.6rem, 5vw, 4.5rem)', color: '#1f2a36' }}>
+              Close More.<br />
+              <span style={{ color: '#557df5' }}>Work Smarter.</span><br />
+              Win Every Time.
             </h1>
-            <p className="text-white/50 text-lg lg:text-xl max-w-lg leading-relaxed">
-              The CRM built for insurance pros who are serious about growth. Leads, pipelines, automation — all in one place.
+
+            <p className="text-lg mb-10 leading-relaxed max-w-md" style={{ color: '#1f2a36', opacity: 0.55 }}>
+              The CRM that moves as fast as you do. Leads, pipelines, automation, and team performance — all in one place, built for the way you actually sell.
             </p>
-          </div>
 
-          {/* Feature grid */}
-          <div className="grid grid-cols-2 gap-4 max-w-lg">
-            {FEATURES.map((f) => (
-              <div
-                key={f.title}
-                className="rounded-2xl border border-white/[0.06] bg-white/[0.04] backdrop-blur-sm p-4 hover:bg-white/[0.08] hover:border-white/10 transition-all duration-200"
-              >
-                <div className="text-2xl mb-2">{f.icon}</div>
-                <div className="text-white font-semibold text-sm mb-1">{f.title}</div>
-                <div className="text-white/40 text-xs leading-relaxed">{f.desc}</div>
-              </div>
-            ))}
-          </div>
-
-          {/* Social proof */}
-          <div className="mt-10 flex items-center gap-4">
-            <div className="flex -space-x-2">
-              {['#2563EB','#0EA5E9','#14B8A6','#06B6D4'].map((c, i) => (
-                <div key={i} className="w-8 h-8 rounded-full border-2 border-[#080C14] flex items-center justify-center text-white text-xs font-bold" style={{background: c}}>
-                  {['J','M','S','A'][i]}
+            {/* Feature grid */}
+            <div className="grid grid-cols-2 gap-3">
+              {FEATURES.map((f) => (
+                <div key={f.title} className="rounded-2xl p-4 border transition-all duration-200 hover:shadow-md" style={{ background: '#fcfcfc', borderColor: '#1f2a3610' }}>
+                  <div className="text-xl mb-2">{f.icon}</div>
+                  <div className="font-semibold text-sm mb-1" style={{ color: '#1f2a36' }}>{f.title}</div>
+                  <div className="text-xs leading-relaxed" style={{ color: '#1f2a36', opacity: 0.45 }}>{f.desc}</div>
                 </div>
               ))}
             </div>
-            <p className="text-white/40 text-sm">
-              <span className="text-white/70 font-semibold">Insurance teams</span> trust King CRM to close more deals
-            </p>
+
+            {/* Social proof */}
+            <div className="mt-8 flex items-center gap-3">
+              <div className="flex -space-x-2">
+                {['#557df5','#3a5fd9','#6b91f7','#4a6ee0'].map((c, i) => (
+                  <div key={i} className="w-8 h-8 rounded-full border-2 flex items-center justify-center text-white text-xs font-bold" style={{ background: c, borderColor: '#fafaf8' }}>
+                    {['J','M','S','R'][i]}
+                  </div>
+                ))}
+              </div>
+              <p className="text-sm" style={{ color: '#1f2a36', opacity: 0.45 }}>
+                <span style={{ opacity: 1, fontWeight: 600 }}>Trusted by insurance teams</span> across the country
+              </p>
+            </div>
           </div>
         </div>
 
         {/* RIGHT — Auth Form */}
-        <div className="flex items-center justify-center px-6 py-12 lg:w-[480px] xl:w-[520px] lg:border-l border-white/[0.06]">
+        <div className="flex items-center justify-center px-6 py-12 lg:py-0 lg:w-[460px] xl:w-[500px] border-t lg:border-t-0 lg:border-l" style={{ borderColor: '#1f2a3608' }}>
           <div className="w-full max-w-sm">
 
-            {/* Form tabs for login/signup */}
+            {/* LOGIN / SIGNUP */}
             {(mode === 'login' || mode === 'signup') && (
               <>
-                <div className="mb-8">
-                  <h2 className="text-2xl font-bold text-white mb-1">
+                <div className="mb-7">
+                  <h2 className="text-2xl font-bold mb-1" style={{ color: '#1f2a36' }}>
                     {mode === 'login' ? 'Welcome back' : 'Create your workspace'}
                   </h2>
-                  <p className="text-white/40 text-sm">
-                    {mode === 'login' ? "Sign in to your King CRM account." : "Get started in under 2 minutes."}
+                  <p className="text-sm" style={{ color: '#1f2a36', opacity: 0.45 }}>
+                    {mode === 'login' ? 'Sign in to your King CRM account.' : 'Get started in under 2 minutes.'}
                   </p>
                 </div>
 
                 {/* Tab switcher */}
-                <div className="flex rounded-xl border border-white/[0.08] bg-white/[0.04] p-1 mb-6">
-                  <button
-                    onClick={() => switchMode('login')}
-                    className={`flex-1 py-2 px-4 rounded-lg text-sm font-semibold transition-all ${
-                      mode === 'login'
-                        ? 'bg-gradient-to-r from-[#2563EB] to-[#0EA5E9] text-white shadow-lg shadow-blue-500/20'
-                        : 'text-white/40 hover:text-white/70'
-                    }`}
-                  >
-                    Sign In
-                  </button>
-                  <button
-                    onClick={() => switchMode('signup')}
-                    className={`flex-1 py-2 px-4 rounded-lg text-sm font-semibold transition-all ${
-                      mode === 'signup'
-                        ? 'bg-gradient-to-r from-[#2563EB] to-[#0EA5E9] text-white shadow-lg shadow-blue-500/20'
-                        : 'text-white/40 hover:text-white/70'
-                    }`}
-                  >
-                    Create Account
-                  </button>
+                <div className="flex rounded-xl border p-1 mb-6" style={{ background: '#fcfcfc', borderColor: '#1f2a3612' }}>
+                  {(['login','signup'] as Mode[]).map((m) => (
+                    <button
+                      key={m}
+                      onClick={() => switchMode(m)}
+                      className="flex-1 py-2 px-4 rounded-lg text-sm font-semibold transition-all duration-150"
+                      style={mode === m ? { background: '#557df5', color: '#fcfcfc', boxShadow: '0 2px 8px #557df530' } : { color: '#1f2a36', opacity: 0.4 }}
+                    >
+                      {m === 'login' ? 'Sign In' : 'Create Account'}
+                    </button>
+                  ))}
                 </div>
 
                 <div className="space-y-4">
                   {mode === 'signup' && (
                     <>
                       <div>
-                        <Label className="text-white/60 text-xs font-semibold uppercase tracking-wider mb-1.5 block">Your name</Label>
-                        <Input
-                          className="bg-white/[0.06] border-white/10 text-white placeholder:text-white/20 focus:border-[#2563EB] focus:ring-[#2563EB]/20 h-11 rounded-xl"
-                          placeholder="Brady Wilson"
-                          value={signupName}
-                          onChange={(e) => setSignupName(e.target.value)}
-                        />
+                        <Label className="text-xs font-semibold uppercase tracking-wider mb-1.5 block" style={{ color: '#1f2a36', opacity: 0.5 }}>Your name</Label>
+                        <Input className="h-11 rounded-xl border text-sm" style={{ background: '#fcfcfc', borderColor: '#1f2a3615', color: '#1f2a36' }} placeholder="Brady Wilson" value={signupName} onChange={(e) => setSignupName(e.target.value)} />
                       </div>
                       <div>
-                        <Label className="text-white/60 text-xs font-semibold uppercase tracking-wider mb-1.5 block">Organization</Label>
-                        <Input
-                          className="bg-white/[0.06] border-white/10 text-white placeholder:text-white/20 focus:border-[#2563EB] focus:ring-[#2563EB]/20 h-11 rounded-xl"
-                          placeholder="Brighter Health Solutions"
-                          value={organizationName}
-                          onChange={(e) => setOrganizationName(e.target.value)}
-                        />
+                        <Label className="text-xs font-semibold uppercase tracking-wider mb-1.5 block" style={{ color: '#1f2a36', opacity: 0.5 }}>Organization</Label>
+                        <Input className="h-11 rounded-xl border text-sm" style={{ background: '#fcfcfc', borderColor: '#1f2a3615', color: '#1f2a36' }} placeholder="Brighter Health Solutions" value={organizationName} onChange={(e) => setOrganizationName(e.target.value)} />
                       </div>
                     </>
                   )}
                   <div>
-                    <Label className="text-white/60 text-xs font-semibold uppercase tracking-wider mb-1.5 block">Email</Label>
-                    <Input
-                      type="email"
-                      className="bg-white/[0.06] border-white/10 text-white placeholder:text-white/20 focus:border-[#2563EB] focus:ring-[#2563EB]/20 h-11 rounded-xl"
-                      placeholder="you@company.com"
-                      value={mode === 'login' ? loginEmail : signupEmail}
-                      onChange={(e) => mode === 'login' ? setLoginEmail(e.target.value) : setSignupEmail(e.target.value)}
-                      onKeyDown={(e) => e.key === 'Enter' && void handleLoginSignup()}
-                    />
+                    <Label className="text-xs font-semibold uppercase tracking-wider mb-1.5 block" style={{ color: '#1f2a36', opacity: 0.5 }}>Email</Label>
+                    <Input type="email" className="h-11 rounded-xl border text-sm" style={{ background: '#fcfcfc', borderColor: '#1f2a3615', color: '#1f2a36' }} placeholder="you@company.com" value={mode === 'login' ? loginEmail : signupEmail} onChange={(e) => mode === 'login' ? setLoginEmail(e.target.value) : setSignupEmail(e.target.value)} onKeyDown={(e) => e.key === 'Enter' && void handleLoginSignup()} />
                   </div>
                   <div>
-                    <Label className="text-white/60 text-xs font-semibold uppercase tracking-wider mb-1.5 block">Password</Label>
-                    <Input
-                      type="password"
-                      className="bg-white/[0.06] border-white/10 text-white placeholder:text-white/20 focus:border-[#2563EB] focus:ring-[#2563EB]/20 h-11 rounded-xl"
-                      placeholder="••••••••"
-                      value={mode === 'login' ? loginPassword : signupPassword}
-                      onChange={(e) => mode === 'login' ? setLoginPassword(e.target.value) : setSignupPassword(e.target.value)}
-                      onKeyDown={(e) => e.key === 'Enter' && void handleLoginSignup()}
-                    />
+                    <Label className="text-xs font-semibold uppercase tracking-wider mb-1.5 block" style={{ color: '#1f2a36', opacity: 0.5 }}>Password</Label>
+                    <Input type="password" className="h-11 rounded-xl border text-sm" style={{ background: '#fcfcfc', borderColor: '#1f2a3615', color: '#1f2a36' }} placeholder="••••••••" value={mode === 'login' ? loginPassword : signupPassword} onChange={(e) => mode === 'login' ? setLoginPassword(e.target.value) : setSignupPassword(e.target.value)} onKeyDown={(e) => e.key === 'Enter' && void handleLoginSignup()} />
                   </div>
 
                   {mode === 'login' && (
                     <div className="flex justify-end">
-                      <button type="button" onClick={() => switchMode('forgot')} className="text-xs text-[#0EA5E9] hover:text-[#2563EB] transition-colors">
+                      <button type="button" onClick={() => switchMode('forgot')} className="text-xs font-medium hover:opacity-80 transition-opacity" style={{ color: '#557df5' }}>
                         Forgot password?
                       </button>
                     </div>
                   )}
 
-                  {error && (
-                    <div className="rounded-xl bg-red-500/10 border border-red-500/20 px-4 py-3 text-sm text-red-400">
-                      {error}
-                    </div>
-                  )}
+                  {error && <div className="rounded-xl px-4 py-3 text-sm border" style={{ background: '#fff0f0', borderColor: '#fca5a520', color: '#dc2626' }}>{error}</div>}
 
                   <button
                     onClick={() => void handleLoginSignup()}
                     disabled={loading}
-                    className="w-full h-11 rounded-xl bg-gradient-to-r from-[#2563EB] to-[#14B8A6] text-white font-semibold text-sm hover:opacity-90 hover:-translate-y-0.5 active:translate-y-0 transition-all duration-150 shadow-lg shadow-blue-500/25 disabled:opacity-50 disabled:cursor-not-allowed disabled:translate-y-0"
+                    className="w-full h-11 rounded-xl font-semibold text-sm transition-all duration-150 hover:opacity-90 hover:-translate-y-0.5 active:translate-y-0 disabled:opacity-50 disabled:cursor-not-allowed"
+                    style={{ background: 'linear-gradient(135deg, #557df5, #3a5fd9)', color: '#fcfcfc', boxShadow: '0 4px 14px #557df530' }}
                   >
                     {loading ? 'Working...' : mode === 'login' ? 'Sign In →' : 'Create Workspace →'}
                   </button>
 
-                  <p className="text-center text-xs text-white/30">
+                  <p className="text-center text-xs" style={{ color: '#1f2a36', opacity: 0.35 }}>
                     Have a reset token?{' '}
-                    <button type="button" onClick={() => switchMode('reset')} className="text-[#0EA5E9] hover:text-white transition-colors">
+                    <button type="button" onClick={() => switchMode('reset')} className="font-medium hover:opacity-80 transition-opacity" style={{ color: '#557df5', opacity: 1 }}>
                       Reset password
                     </button>
                   </p>
@@ -305,55 +263,32 @@ export default function AuthPage() {
             {/* FORGOT PASSWORD */}
             {mode === 'forgot' && (
               <>
-                <div className="mb-8">
-                  <button onClick={() => switchMode('login')} className="text-white/40 hover:text-white text-sm mb-4 flex items-center gap-1 transition-colors">
-                    ← Back
-                  </button>
-                  <h2 className="text-2xl font-bold text-white mb-1">Reset your password</h2>
-                  <p className="text-white/40 text-sm">Enter your email to get a reset token.</p>
+                <button onClick={() => switchMode('login')} className="text-sm mb-6 flex items-center gap-1 font-medium hover:opacity-70 transition-opacity" style={{ color: '#1f2a36', opacity: 0.5 }}>← Back</button>
+                <div className="mb-7">
+                  <h2 className="text-2xl font-bold mb-1" style={{ color: '#1f2a36' }}>Reset password</h2>
+                  <p className="text-sm" style={{ color: '#1f2a36', opacity: 0.45 }}>Enter your email to get a reset token.</p>
                 </div>
                 <div className="space-y-4">
                   <div>
-                    <Label className="text-white/60 text-xs font-semibold uppercase tracking-wider mb-1.5 block">Email address</Label>
-                    <Input
-                      type="email"
-                      className="bg-white/[0.06] border-white/10 text-white placeholder:text-white/20 focus:border-[#2563EB] h-11 rounded-xl"
-                      placeholder="you@company.com"
-                      value={forgotEmail}
-                      onChange={(e) => setForgotEmail(e.target.value)}
-                      onKeyDown={(e) => e.key === 'Enter' && void handleForgotPassword()}
-                    />
+                    <Label className="text-xs font-semibold uppercase tracking-wider mb-1.5 block" style={{ color: '#1f2a36', opacity: 0.5 }}>Email address</Label>
+                    <Input type="email" className="h-11 rounded-xl border text-sm" style={{ background: '#fcfcfc', borderColor: '#1f2a3615', color: '#1f2a36' }} placeholder="you@company.com" value={forgotEmail} onChange={(e) => setForgotEmail(e.target.value)} onKeyDown={(e) => e.key === 'Enter' && void handleForgotPassword()} />
                   </div>
-                  {error && <div className="rounded-xl bg-red-500/10 border border-red-500/20 px-4 py-3 text-sm text-red-400">{error}</div>}
-                  {success && <div className="rounded-xl bg-emerald-500/10 border border-emerald-500/20 px-4 py-3 text-sm text-emerald-400">{success}</div>}
+                  {error && <div className="rounded-xl px-4 py-3 text-sm border" style={{ background: '#fff0f0', borderColor: '#fca5a520', color: '#dc2626' }}>{error}</div>}
+                  {success && <div className="rounded-xl px-4 py-3 text-sm border" style={{ background: '#f0fdf4', borderColor: '#86efac30', color: '#16a34a' }}>{success}</div>}
                   {resetTokenDisplay && (
-                    <div className="rounded-xl border border-[#2563EB]/30 bg-[#2563EB]/10 p-4 space-y-3">
-                      <p className="text-sm font-semibold text-white">Your reset token (expires in 1 hour):</p>
+                    <div className="rounded-xl border p-4 space-y-3" style={{ background: '#fcf8ec', borderColor: '#557df520' }}>
+                      <p className="text-sm font-semibold" style={{ color: '#1f2a36' }}>Your reset token (expires in 1 hour):</p>
                       <div className="flex items-center gap-2">
-                        <code className="flex-1 break-all rounded-lg bg-white/[0.06] px-3 py-2 text-xs font-mono text-[#0EA5E9]">
-                          {resetTokenDisplay}
-                        </code>
-                        <button
-                          onClick={() => void navigator.clipboard.writeText(resetTokenDisplay)}
-                          className="shrink-0 px-3 py-2 rounded-lg border border-white/10 text-white/60 hover:text-white text-xs transition-colors"
-                        >
-                          Copy
-                        </button>
+                        <code className="flex-1 break-all rounded-lg px-3 py-2 text-xs font-mono" style={{ background: '#fcfcfc', color: '#557df5', border: '1px solid #557df520' }}>{resetTokenDisplay}</code>
+                        <button onClick={() => void navigator.clipboard.writeText(resetTokenDisplay)} className="shrink-0 px-3 py-2 rounded-lg border text-xs font-medium transition-colors hover:opacity-80" style={{ borderColor: '#1f2a3615', color: '#1f2a36' }}>Copy</button>
                       </div>
-                      <button
-                        onClick={() => { setResetToken(resetTokenDisplay); switchMode('reset') }}
-                        className="w-full h-10 rounded-xl bg-gradient-to-r from-[#2563EB] to-[#14B8A6] text-white font-semibold text-sm hover:opacity-90 transition-all"
-                      >
+                      <button onClick={() => { setResetToken(resetTokenDisplay); switchMode('reset') }} className="w-full h-10 rounded-xl font-semibold text-sm transition-all hover:opacity-90" style={{ background: 'linear-gradient(135deg, #557df5, #3a5fd9)', color: '#fcfcfc' }}>
                         Use this token →
                       </button>
                     </div>
                   )}
                   {!resetTokenDisplay && (
-                    <button
-                      onClick={() => void handleForgotPassword()}
-                      disabled={loading}
-                      className="w-full h-11 rounded-xl bg-gradient-to-r from-[#2563EB] to-[#14B8A6] text-white font-semibold text-sm hover:opacity-90 transition-all shadow-lg shadow-blue-500/25 disabled:opacity-50"
-                    >
+                    <button onClick={() => void handleForgotPassword()} disabled={loading} className="w-full h-11 rounded-xl font-semibold text-sm transition-all hover:opacity-90 disabled:opacity-50" style={{ background: 'linear-gradient(135deg, #557df5, #3a5fd9)', color: '#fcfcfc', boxShadow: '0 4px 14px #557df530' }}>
                       {loading ? 'Working...' : 'Get Reset Token →'}
                     </button>
                   )}
@@ -364,47 +299,35 @@ export default function AuthPage() {
             {/* RESET PASSWORD */}
             {mode === 'reset' && (
               <>
-                <div className="mb-8">
-                  <button onClick={() => switchMode('forgot')} className="text-white/40 hover:text-white text-sm mb-4 flex items-center gap-1 transition-colors">
-                    ← Back
-                  </button>
-                  <h2 className="text-2xl font-bold text-white mb-1">Set new password</h2>
-                  <p className="text-white/40 text-sm">Enter your reset token and choose a new password.</p>
+                <button onClick={() => switchMode('forgot')} className="text-sm mb-6 flex items-center gap-1 font-medium hover:opacity-70 transition-opacity" style={{ color: '#1f2a36', opacity: 0.5 }}>← Back</button>
+                <div className="mb-7">
+                  <h2 className="text-2xl font-bold mb-1" style={{ color: '#1f2a36' }}>Set new password</h2>
+                  <p className="text-sm" style={{ color: '#1f2a36', opacity: 0.45 }}>Enter your reset token and choose a new password.</p>
                 </div>
                 <div className="space-y-4">
                   <div>
-                    <Label className="text-white/60 text-xs font-semibold uppercase tracking-wider mb-1.5 block">Reset token</Label>
-                    <Input
-                      className="bg-white/[0.06] border-white/10 text-white font-mono text-sm placeholder:text-white/20 focus:border-[#2563EB] h-11 rounded-xl"
-                      placeholder="Paste your reset token"
-                      value={resetToken}
-                      onChange={(e) => setResetToken(e.target.value)}
-                    />
+                    <Label className="text-xs font-semibold uppercase tracking-wider mb-1.5 block" style={{ color: '#1f2a36', opacity: 0.5 }}>Reset token</Label>
+                    <Input className="h-11 rounded-xl border text-sm font-mono" style={{ background: '#fcfcfc', borderColor: '#1f2a3615', color: '#1f2a36' }} placeholder="Paste your reset token" value={resetToken} onChange={(e) => setResetToken(e.target.value)} />
                   </div>
                   <div>
-                    <Label className="text-white/60 text-xs font-semibold uppercase tracking-wider mb-1.5 block">New password</Label>
-                    <Input type="password" className="bg-white/[0.06] border-white/10 text-white placeholder:text-white/20 focus:border-[#2563EB] h-11 rounded-xl" placeholder="••••••••" value={newPassword} onChange={(e) => setNewPassword(e.target.value)} />
+                    <Label className="text-xs font-semibold uppercase tracking-wider mb-1.5 block" style={{ color: '#1f2a36', opacity: 0.5 }}>New password</Label>
+                    <Input type="password" className="h-11 rounded-xl border text-sm" style={{ background: '#fcfcfc', borderColor: '#1f2a3615', color: '#1f2a36' }} placeholder="••••••••" value={newPassword} onChange={(e) => setNewPassword(e.target.value)} />
                   </div>
                   <div>
-                    <Label className="text-white/60 text-xs font-semibold uppercase tracking-wider mb-1.5 block">Confirm password</Label>
-                    <Input type="password" className="bg-white/[0.06] border-white/10 text-white placeholder:text-white/20 focus:border-[#2563EB] h-11 rounded-xl" placeholder="••••••••" value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} onKeyDown={(e) => e.key === 'Enter' && void handleResetPassword()} />
+                    <Label className="text-xs font-semibold uppercase tracking-wider mb-1.5 block" style={{ color: '#1f2a36', opacity: 0.5 }}>Confirm password</Label>
+                    <Input type="password" className="h-11 rounded-xl border text-sm" style={{ background: '#fcfcfc', borderColor: '#1f2a3615', color: '#1f2a36' }} placeholder="••••••••" value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} onKeyDown={(e) => e.key === 'Enter' && void handleResetPassword()} />
                   </div>
-                  {error && <div className="rounded-xl bg-red-500/10 border border-red-500/20 px-4 py-3 text-sm text-red-400">{error}</div>}
-                  {success && <div className="rounded-xl bg-emerald-500/10 border border-emerald-500/20 px-4 py-3 text-sm text-emerald-400">{success}</div>}
-                  <button
-                    onClick={() => void handleResetPassword()}
-                    disabled={loading}
-                    className="w-full h-11 rounded-xl bg-gradient-to-r from-[#2563EB] to-[#14B8A6] text-white font-semibold text-sm hover:opacity-90 transition-all shadow-lg shadow-blue-500/25 disabled:opacity-50"
-                  >
+                  {error && <div className="rounded-xl px-4 py-3 text-sm border" style={{ background: '#fff0f0', borderColor: '#fca5a520', color: '#dc2626' }}>{error}</div>}
+                  {success && <div className="rounded-xl px-4 py-3 text-sm border" style={{ background: '#f0fdf4', borderColor: '#86efac30', color: '#16a34a' }}>{success}</div>}
+                  <button onClick={() => void handleResetPassword()} disabled={loading} className="w-full h-11 rounded-xl font-semibold text-sm transition-all hover:opacity-90 disabled:opacity-50" style={{ background: 'linear-gradient(135deg, #557df5, #3a5fd9)', color: '#fcfcfc', boxShadow: '0 4px 14px #557df530' }}>
                     {loading ? 'Resetting...' : 'Reset Password →'}
                   </button>
                 </div>
               </>
             )}
 
-            {/* Footer */}
-            <p className="mt-8 text-center text-xs text-white/20">
-              © 2026 King CRM Hub · Built for insurance pros
+            <p className="mt-8 text-center text-xs" style={{ color: '#1f2a36', opacity: 0.25 }}>
+              © 2026 King CRM Hub · Built for insurance professionals
             </p>
           </div>
         </div>

--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -112,7 +112,7 @@ export default function AuthPage() {
   }
 
   return (
-    <main className="min-h-screen overflow-hidden" style={{ background: '#fafaf8' }}>
+    <main className="min-h-screen overflow-hidden" style={{ background: '#fcf8ec' }}>
 
       {/* Top nav bar */}
       <nav className="absolute top-0 left-0 right-0 z-20 flex items-center justify-between px-8 py-5">
@@ -167,7 +167,7 @@ export default function AuthPage() {
             <div className="mt-8 flex items-center gap-3">
               <div className="flex -space-x-2">
                 {['#557df5','#3a5fd9','#6b91f7','#4a6ee0'].map((c, i) => (
-                  <div key={i} className="w-8 h-8 rounded-full border-2 flex items-center justify-center text-white text-xs font-bold" style={{ background: c, borderColor: '#fafaf8' }}>
+                  <div key={i} className="w-8 h-8 rounded-full border-2 flex items-center justify-center text-white text-xs font-bold" style={{ background: c, borderColor: '#fcf8ec' }}>
                     {['J','M','S','R'][i]}
                   </div>
                 ))}


### PR DESCRIPTION
## What this changes

Full redesign of the auth/landing page.

**Before:** Plain card with 'Insurafuze CRM' title on white background

**After:**
- Dark immersive hero (`#080C14`) with animated blue/teal glow effects
- Bold headline: *Close More. Work Less. Win Always.*
- Feature grid: Lead Management, Pipeline Analytics, Automated Sequences, Team Performance
- Social proof bar
- Split-layout: hero left, auth form right
- Branding changed to **King CRM Hub** / **King CRM** throughout
- Same full auth flow preserved: sign in, create account, forgot password, reset password
- Matches existing cobalt/teal design system (`#2563EB` / `#14B8A6` gradients)
- Mobile responsive

## Files changed
- `src/app/auth/page.tsx` — complete redesign

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilt the auth/landing page into a premium King CRM Hub experience with a warm cream (#fcf8ec) and blue palette, split hero + auth layout, and polished copy. The full auth flow remains, including the secure token-based password reset backed by new API routes and a Prisma model.

- **New Features**
  - Top nav plus left-side hero with updated headline, feature grid, and social proof; responsive and on-brand with accents `#557df5` and `#1f2a36`.
  - Right-side auth with a simple sign in/create toggle, improved error/success states, and a clearer forgot/reset flow (copyable token, concise messages).
  - Keeps `/api/auth/forgot-password` and `/api/auth/reset-password` with CSRF same-origin checks and rate limiting; `PasswordResetToken` model tracks expiry/usage and invalidates sessions on reset.

- **Migration**
  - Run Prisma migrations to add the `PasswordResetToken` table and indexes. Restart the app to load the new API routes.

<sup>Written for commit 79abef3a95ccb0adb056036a59ba20f67cf8f5b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

