### PR TITLE
Visual Overhaul: Cream + Cobalt Design System

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -44,128 +44,86 @@
   --color-success: var(--success);
   --color-warning: var(--warning);
   --color-info: var(--info);
-  --color-gold: var(--gold);
-  --color-gold-light: var(--gold-light);
-  --color-cream: var(--cream);
-  --color-cream-dark: var(--cream-dark);
 }
 
 /* ============================================
-   ELITE DESIGN SYSTEM - MODERN OCEAN THEME
-   Light slate background with cobalt and teal accents
+   KING CRM HUB - ELITE DESIGN SYSTEM
+   Cream background with cobalt blue accents
+   Landing page aesthetic applied globally
    ============================================ */
 
 :root {
-  --radius: 0.5rem;
+  --radius: 0.75rem;
   
-  /* Luxury Gold & Cream Palette */
-  --gold: #2563EB;
-  --gold-light: #14B8A6;
-  --gold-dark: #0EA5E9;
-  --gold-subtle: rgba(212, 175, 55, 0.15);
+  /* Primary Palette - Cobalt Blue */
+  --cobalt: #557df5;
+  --cobalt-dark: #3a5fd9;
+  --cobalt-light: #6b91f7;
+  --cobalt-subtle: rgba(85, 125, 245, 0.12);
   
-  /* Cream/Ivory Backgrounds */
-  --cream: #F5F7FB;
-  --cream-dark: #EEF2F7;
-  --cream-darker: #F0EBE0;
+  /* Cream Background System */
+  --cream: #fcf8ec;
+  --cream-light: #fcfcfc;
+  --cream-warm: #f5f0e6;
+  --cream-border: rgba(31, 42, 54, 0.08);
   
-  /* Pure blacks and whites */
-  --black: #0F172A;
-  --white: #FFFFFF;
-  
-  /* Base Theme - Light Cream with Gold Accents */
-  --background: #F5F7FB;
-  --foreground: #0F172A;
-  --card: #FFFFFF;
-  --card-foreground: #0F172A;
-  --popover: #FFFFFF;
-  --popover-foreground: #0F172A;
-  
-  /* Primary Accent - Bright Gold */
-  --primary: #2563EB;
-  --primary-foreground: #0F172A;
-  
-  /* Secondary - Black */
-  --secondary: #0F172A;
-  --secondary-foreground: #FFFFFF;
-  
-  /* Muted - Cream tones */
-  --muted: #EEF2F7;
-  --muted-foreground: #6B6B6B;
-  --accent: #F0EBE0;
-  --accent-foreground: #0F172A;
+  /* Text Colors */
+  --navy: #1f2a36;
+  --navy-light: rgba(31, 42, 54, 0.55);
+  --navy-muted: rgba(31, 42, 54, 0.45);
   
   /* Semantic Colors */
-  --destructive: #DC2626;
-  --success: #059669;
-  --warning: #2563EB;
-  --info: #0284C7;
+  --success: #16a34a;
+  --success-light: #f0fdf4;
+  --warning: #ea580c;
+  --warning-light: #fff7ed;
+  --destructive: #dc2626;
+  --destructive-light: #fef2f2;
+  --info: #557df5;
+  
+  /* Base Theme */
+  --background: #fcf8ec;
+  --foreground: #1f2a36;
+  --card: #fcfcfc;
+  --card-foreground: #1f2a36;
+  --popover: #fcfcfc;
+  --popover-foreground: #1f2a36;
+  
+  /* Primary - Cobalt */
+  --primary: #557df5;
+  --primary-foreground: #ffffff;
+  
+  /* Secondary - Navy */
+  --secondary: #1f2a36;
+  --secondary-foreground: #ffffff;
+  
+  /* Muted - Cream tones */
+  --muted: #f5f0e6;
+  --muted-foreground: rgba(31, 42, 54, 0.55);
+  --accent: rgba(85, 125, 245, 0.08);
+  --accent-foreground: #1f2a36;
   
   /* Borders & Inputs */
-  --border: #D7DFEA;
-  --input: #D7DFEA;
-  --ring: #2563EB;
+  --border: rgba(31, 42, 54, 0.12);
+  --input: rgba(31, 42, 54, 0.15);
+  --ring: #557df5;
   
-  /* Charts - Gold-centric palette */
-  --chart-1: #2563EB;
-  --chart-2: #0F172A;
-  --chart-3: #0EA5E9;
-  --chart-4: #14B8A6;
-  --chart-5: #64748B;
+  /* Charts - Cobalt palette */
+  --chart-1: #557df5;
+  --chart-2: #3a5fd9;
+  --chart-3: #6b91f7;
+  --chart-4: #4a6ee0;
+  --chart-5: #1f2a36;
   
-  /* Sidebar - Premium dark for contrast */
-  --sidebar: #0F172A;
-  --sidebar-foreground: #FFFFFF;
-  --sidebar-primary: #2563EB;
-  --sidebar-primary-foreground: #0F172A;
-  --sidebar-accent: #1E293B;
-  --sidebar-accent-foreground: #FFFFFF;
-  --sidebar-border: #334155;
-  --sidebar-ring: #2563EB;
-}
-
-/* Dark mode - Optional (user can toggle) */
-.dark {
-  --background: #0F172A;
-  --foreground: #FFFFFF;
-  --card: #141414;
-  --card-foreground: #FFFFFF;
-  --popover: #141414;
-  --popover-foreground: #FFFFFF;
-  
-  --primary: #2563EB;
-  --primary-foreground: #0F172A;
-  
-  --secondary: #1E293B;
-  --secondary-foreground: #FFFFFF;
-  --muted: #1E293B;
-  --muted-foreground: #A0A0A0;
-  --accent: #334155;
-  --accent-foreground: #FFFFFF;
-  
-  --destructive: #EF4444;
-  --success: #10B981;
-  --warning: #2563EB;
-  --info: #0EA5E9;
-  
-  --border: #334155;
-  --input: #334155;
-  --ring: #2563EB;
-  
-  --chart-1: #2563EB;
-  --chart-2: #FFFFFF;
-  --chart-3: #0EA5E9;
-  --chart-4: #14B8A6;
-  --chart-5: #64748B;
-  
-  --sidebar: #0F172A;
-  --sidebar-foreground: #FFFFFF;
-  --sidebar-primary: #2563EB;
-  --sidebar-primary-foreground: #0F172A;
-  --sidebar-accent: #1E293B;
-  --sidebar-accent-foreground: #FFFFFF;
-  --sidebar-border: #334155;
-  --sidebar-ring: #2563EB;
+  /* Sidebar */
+  --sidebar: #1f2a36;
+  --sidebar-foreground: #ffffff;
+  --sidebar-primary: #557df5;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: rgba(85, 125, 245, 0.15);
+  --sidebar-accent-foreground: #ffffff;
+  --sidebar-border: rgba(255, 255, 255, 0.1);
+  --sidebar-ring: #557df5;
 }
 
 @layer base {
@@ -178,269 +136,109 @@
   }
 }
 
-/* Elite Scrollbar - Cobalt accent */
+/* ============================================
+   SCROLLBAR - Cobalt accent
+   ============================================ */
 ::-webkit-scrollbar {
   width: 8px;
   height: 8px;
 }
 
 ::-webkit-scrollbar-track {
-  background: var(--cream-dark);
+  background: var(--cream-warm);
 }
 
 ::-webkit-scrollbar-thumb {
-  background: var(--gold);
+  background: var(--cobalt);
   border-radius: 4px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: var(--gold-dark);
+  background: var(--cobalt-dark);
 }
 
-.dark ::-webkit-scrollbar-track {
-  background: #1E293B;
-}
-
-.dark ::-webkit-scrollbar-thumb {
-  background: #0EA5E9;
-}
-
-/* AI Glow Effects - Cobalt */
-.ai-glow {
-  box-shadow: 0 0 20px rgba(37, 99, 235, 0.4), 0 0 40px rgba(20, 184, 166, 0.18);
-}
-
-.ai-glow-success {
-  box-shadow: 0 0 20px rgba(5, 150, 105, 0.4), 0 0 40px rgba(5, 150, 105, 0.2);
-}
-
-.ai-glow-warning {
-  box-shadow: 0 0 20px rgba(37, 99, 235, 0.4), 0 0 40px rgba(20, 184, 166, 0.18);
-}
-
-/* Glass Effect */
-.glass {
-  background: rgba(245, 247, 251, 0.9);
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
-  border: 1px solid rgba(37, 99, 235, 0.16);
-}
-
-.dark .glass {
-  background: rgba(20, 20, 20, 0.9);
-  border: 1px solid rgba(20, 184, 166, 0.22);
-}
-
-/* Gradient Text - Cobalt */
-.gradient-text {
-  background: linear-gradient(135deg, #2563EB, #14B8A6);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-}
-
-/* Animated Gradient Border - Cobalt */
-.gradient-border {
-  position: relative;
-  background: var(--card);
-}
-
-.gradient-border::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  padding: 2px;
-  background: linear-gradient(135deg, #2563EB, #14B8A6, #2563EB);
-  -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
-  mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
-  -webkit-mask-composite: xor;
-  mask-composite: exclude;
-  pointer-events: none;
-}
-
-/* Primary Button Style */
-.btn-gold {
-  background: linear-gradient(135deg, #2563EB, #14B8A6);
-  color: #FFFFFF;
+/* ============================================
+   BUTTONS - Primary cobalt gradient
+   ============================================ */
+.btn-primary {
+  background: linear-gradient(135deg, #557df5, #3a5fd9);
+  color: #ffffff;
   font-weight: 600;
   border: none;
+  border-radius: 0.75rem;
   transition: all 0.2s ease;
+  box-shadow: 0 4px 14px rgba(85, 125, 245, 0.35);
 }
 
-.btn-gold:hover {
-  background: linear-gradient(135deg, #0EA5E9, #2563EB);
+.btn-primary:hover {
+  background: linear-gradient(135deg, #6b91f7, #557df5);
   transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(37, 99, 235, 0.28);
+  box-shadow: 0 6px 20px rgba(85, 125, 245, 0.45);
 }
 
-/* Black Button Style */
-.btn-black {
-  background: #0F172A;
-  color: #FFFFFF;
+.btn-primary:active {
+  transform: translateY(0);
+}
+
+.btn-secondary {
+  background: var(--navy);
+  color: #ffffff;
   font-weight: 500;
   border: none;
+  border-radius: 0.75rem;
   transition: all 0.2s ease;
 }
 
-.btn-black:hover {
-  background: #1E293B;
+.btn-secondary:hover {
+  background: rgba(31, 42, 54, 0.9);
   transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
 }
 
-/* Shimmer Loading Effect */
-@keyframes shimmer {
-  0% {
-    background-position: -200% 0;
-  }
-  100% {
-    background-position: 200% 0;
-  }
+.btn-outline {
+  background: transparent;
+  color: var(--cobalt);
+  font-weight: 500;
+  border: 1.5px solid var(--cobalt);
+  border-radius: 0.75rem;
+  transition: all 0.2s ease;
 }
 
-.animate-shimmer {
-  background: linear-gradient(
-    90deg,
-    var(--cream-dark) 25%,
-    var(--cream) 50%,
-    var(--cream-dark) 75%
-  );
-  background-size: 200% 100%;
-  animation: shimmer 1.5s infinite;
+.btn-outline:hover {
+  background: var(--cobalt-subtle);
 }
 
-.dark .animate-shimmer {
-  background: linear-gradient(
-    90deg,
-    #1E293B 25%,
-    #334155 50%,
-    #1E293B 75%
-  );
-  background-size: 200% 100%;
+.btn-ghost {
+  background: transparent;
+  color: var(--navy);
+  font-weight: 500;
+  border: none;
+  border-radius: 0.75rem;
+  transition: all 0.2s ease;
 }
 
-/* Pulse Animation for AI elements */
-@keyframes pulse-ai {
-  0%, 100% {
-    opacity: 1;
-    box-shadow: 0 0 20px rgba(37, 99, 235, 0.4);
-  }
-  50% {
-    opacity: 0.9;
-    box-shadow: 0 0 30px rgba(20, 184, 166, 0.5);
-  }
+.btn-ghost:hover {
+  background: rgba(31, 42, 54, 0.05);
 }
 
-.animate-pulse-ai {
-  animation: pulse-ai 2s ease-in-out infinite;
+/* ============================================
+   CARDS - Clean with subtle borders
+   ============================================ */
+.card-elite {
+  background: var(--cream-light);
+  border: 1px solid var(--cream-border);
+  border-radius: 1rem;
+  transition: all 0.2s ease;
 }
 
-/* Card Hover Effects */
-.card-hover {
-  transition: all 0.2s ease-in-out;
-  border: 1px solid var(--border);
+.card-elite:hover {
+  border-color: rgba(85, 125, 245, 0.3);
+  box-shadow: 0 8px 24px rgba(31, 42, 54, 0.08);
 }
 
-.card-hover:hover {
-  transform: translateY(-2px);
-  border-color: var(--gold);
-  box-shadow: 0 8px 24px rgba(37, 99, 235, 0.12);
-}
-
-/* Status Badge Colors - Ocean Theme */
-.status-new {
-  background: #0F172A;
-  color: #FFFFFF;
-}
-
-.status-hot {
-  background: linear-gradient(135deg, #2563EB, #14B8A6);
-  color: #0F172A;
-}
-
-.status-qualified {
-  background: #2563EB;
-  color: #0F172A;
-}
-
-.status-nurture {
-  background: #64748B;
-  color: #FFFFFF;
-}
-
-.status-sold {
-  background: #059669;
-  color: #FFFFFF;
-}
-
-.status-lost {
-  background: #DC2626;
-  color: #FFFFFF;
-}
-
-.status-proposal {
-  background: #0284C7;
-  color: #FFFFFF;
-}
-
-.status-negotiation {
-  background: #1E293B;
-  color: #2563EB;
-}
-
-/* Kanban Column Colors - Ocean Theme */
-.kanban-new { border-top: 3px solid #0F172A; }
-.kanban-contacted { border-top: 3px solid #6B7280; }
-.kanban-qualified { border-top: 3px solid #2563EB; }
-.kanban-proposal { border-top: 3px solid #0284C7; }
-.kanban-negotiation { border-top: 3px solid #64748B; }
-.kanban-won { border-top: 3px solid #059669; }
-.kanban-lost { border-top: 3px solid #DC2626; }
-
-/* Focus States - Accessibility with Cobalt ring */
-.focus-ring:focus-visible {
-  outline: 2px solid var(--gold);
-  outline-offset: 2px;
-}
-
-/* Transitions */
-.transition-smooth {
-  transition: all 0.2s ease-in-out;
-}
-
-/* Text Utilities */
-.text-balance {
-  text-wrap: balance;
-}
-
-/* Accent underline for links */
-.link-gold {
-  position: relative;
-  color: var(--gold-dark);
-  text-decoration: none;
-}
-
-.link-gold::after {
-  content: '';
-  position: absolute;
-  bottom: -2px;
-  left: 0;
-  width: 0;
-  height: 2px;
-  background: var(--gold);
-  transition: width 0.2s ease;
-}
-
-.link-gold:hover::after {
-  width: 100%;
-}
-
-/* Premium card with accent border */
 .card-premium {
-  background: var(--white);
-  border: 1px solid var(--border);
-  border-radius: 12px;
+  background: var(--cream-light);
+  border: 1px solid var(--cream-border);
+  border-radius: 1rem;
   position: relative;
   overflow: hidden;
 }
@@ -452,21 +250,185 @@
   left: 0;
   right: 0;
   height: 3px;
-  background: linear-gradient(90deg, #2563EB, #14B8A6, #2563EB);
+  background: linear-gradient(90deg, #557df5, #6b91f7, #557df5);
 }
 
-/* Accent divider */
-.divider-gold {
+/* ============================================
+   INPUTS - Rounded with cream background
+   ============================================ */
+.input-elite {
+  background: var(--cream-light);
+  border: 1px solid rgba(31, 42, 54, 0.15);
+  border-radius: 0.75rem;
+  color: var(--navy);
+  transition: all 0.2s ease;
+}
+
+.input-elite:focus {
+  border-color: var(--cobalt);
+  box-shadow: 0 0 0 3px rgba(85, 125, 245, 0.15);
+  outline: none;
+}
+
+.input-elite::placeholder {
+  color: rgba(31, 42, 54, 0.35);
+}
+
+/* ============================================
+   STATUS BADGES
+   ============================================ */
+.badge-status {
+  padding: 0.25rem 0.75rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.badge-new { background: var(--navy); color: white; }
+.badge-contacted { background: rgba(31, 42, 54, 0.6); color: white; }
+.badge-qualified { background: var(--cobalt); color: white; }
+.badge-proposal { background: #0284c7; color: white; }
+.badge-negotiation { background: #64748b; color: white; }
+.badge-won { background: var(--success); color: white; }
+.badge-lost { background: var(--destructive); color: white; }
+
+/* ============================================
+   AI GLOW EFFECTS
+   ============================================ */
+.ai-glow {
+  box-shadow: 0 0 20px rgba(85, 125, 245, 0.35), 0 0 40px rgba(85, 125, 245, 0.15);
+}
+
+.ai-glow-success {
+  box-shadow: 0 0 20px rgba(22, 163, 74, 0.35), 0 0 40px rgba(22, 163, 74, 0.15);
+}
+
+/* ============================================
+   GRADIENT TEXT
+   ============================================ */
+.gradient-text {
+  background: linear-gradient(135deg, #557df5, #3a5fd9);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+/* ============================================
+   GLASS EFFECT
+   ============================================ */
+.glass {
+  background: rgba(252, 248, 236, 0.95);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid rgba(85, 125, 245, 0.15);
+}
+
+/* ============================================
+   ANIMATIONS
+   ============================================ */
+@keyframes shimmer {
+  0% { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+}
+
+.animate-shimmer {
+  background: linear-gradient(90deg, var(--cream-warm) 25%, var(--cream-light) 50%, var(--cream-warm) 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite;
+}
+
+@keyframes pulse-cobalt {
+  0%, 100% { box-shadow: 0 0 20px rgba(85, 125, 245, 0.35); }
+  50% { box-shadow: 0 0 30px rgba(85, 125, 245, 0.5); }
+}
+
+.animate-pulse-cobalt {
+  animation: pulse-cobalt 2s ease-in-out infinite;
+}
+
+/* ============================================
+   KANBAN STYLES
+   ============================================ */
+.kanban-column {
+  background: var(--cream-light);
+  border: 1px solid var(--cream-border);
+  border-radius: 0.75rem;
+}
+
+.kanban-card {
+  background: white;
+  border: 1px solid var(--cream-border);
+  border-radius: 0.75rem;
+  transition: all 0.2s ease;
+}
+
+.kanban-card:hover {
+  border-color: rgba(85, 125, 245, 0.3);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(31, 42, 54, 0.08);
+}
+
+/* ============================================
+   SIDEBAR NAVIGATION
+   ============================================ */
+.nav-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  color: rgba(255, 255, 255, 0.7);
+  transition: all 0.2s ease;
+}
+
+.nav-item:hover {
+  background: rgba(85, 125, 245, 0.15);
+  color: white;
+}
+
+.nav-item.active {
+  background: var(--cobalt);
+  color: white;
+}
+
+/* ============================================
+   FOCUS STATES
+   ============================================ */
+.focus-ring:focus-visible {
+  outline: 2px solid var(--cobalt);
+  outline-offset: 2px;
+}
+
+/* ============================================
+   LINKS
+   ============================================ */
+.link-cobalt {
+  color: var(--cobalt);
+  text-decoration: none;
+  font-weight: 500;
+  transition: opacity 0.2s ease;
+}
+
+.link-cobalt:hover {
+  opacity: 0.8;
+}
+
+/* ============================================
+   DIVIDERS
+   ============================================ */
+.divider-cobalt {
   height: 1px;
-  background: linear-gradient(90deg, transparent, #2563EB, transparent);
+  background: linear-gradient(90deg, transparent, #557df5, transparent);
 }
 
-/* Score indicator with accent */
+/* ============================================
+   SCORE INDICATOR
+   ============================================ */
 .score-indicator {
   position: relative;
   width: 100%;
   height: 8px;
-  background: var(--cream-dark);
+  background: var(--cream-warm);
   border-radius: 4px;
   overflow: hidden;
 }
@@ -477,27 +439,125 @@
   left: 0;
   top: 0;
   height: 100%;
-  background: linear-gradient(90deg, #0F172A, #2563EB);
+  background: linear-gradient(90deg, var(--navy), var(--cobalt));
   border-radius: 4px;
   transition: width 0.3s ease;
 }
 
-/* CSV Upload Drop Zone */
+/* ============================================
+   UPLOAD ZONE
+   ============================================ */
 .upload-zone {
-  border: 2px dashed var(--gold);
-  background: var(--cream);
+  border: 2px dashed var(--cobalt);
+  background: var(--cobalt-subtle);
+  border-radius: 1rem;
   transition: all 0.2s ease;
 }
 
 .upload-zone:hover,
 .upload-zone.drag-over {
-  border-color: var(--gold-dark);
-  background: var(--gold-subtle);
+  border-color: var(--cobalt-dark);
+  background: rgba(85, 125, 245, 0.18);
 }
 
-/* Responsive Typography */
-@media (max-width: 640px) {
-  .responsive-text-sm { font-size: 0.875rem; }
-  .responsive-text-base { font-size: 1rem; }
-  .responsive-text-lg { font-size: 1.125rem; }
+/* ============================================
+   STATS CARDS
+   ============================================ */
+.stat-card {
+  background: var(--cream-light);
+  border: 1px solid var(--cream-border);
+  border-radius: 1rem;
+  padding: 1.25rem;
+  transition: all 0.2s ease;
+}
+
+.stat-card:hover {
+  border-color: rgba(85, 125, 245, 0.25);
+  box-shadow: 0 4px 16px rgba(31, 42, 54, 0.06);
+}
+
+.stat-icon {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 0.75rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--cobalt-subtle);
+  color: var(--cobalt);
+}
+
+/* ============================================
+   TABLE STYLES
+   ============================================ */
+.table-elite {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+}
+
+.table-elite th {
+  background: var(--cream-warm);
+  padding: 0.75rem 1rem;
+  text-align: left;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--navy-light);
+  border-bottom: 1px solid var(--cream-border);
+}
+
+.table-elite td {
+  padding: 1rem;
+  border-bottom: 1px solid var(--cream-border);
+  color: var(--navy);
+}
+
+.table-elite tr:hover td {
+  background: var(--cream-warm);
+}
+
+/* ============================================
+   MODAL/DIALOG
+   ============================================ */
+.dialog-elite {
+  background: var(--cream-light);
+  border: 1px solid var(--cream-border);
+  border-radius: 1rem;
+  box-shadow: 0 24px 48px rgba(31, 42, 54, 0.15);
+}
+
+/* ============================================
+   TOAST NOTIFICATIONS
+   ============================================ */
+.toast-success {
+  background: var(--success-light);
+  border: 1px solid rgba(22, 163, 74, 0.2);
+  color: var(--success);
+}
+
+.toast-error {
+  background: var(--destructive-light);
+  border: 1px solid rgba(220, 38, 38, 0.2);
+  color: var(--destructive);
+}
+
+.toast-warning {
+  background: var(--warning-light);
+  border: 1px solid rgba(234, 88, 12, 0.2);
+  color: var(--warning);
+}
+
+/* ============================================
+   RESPONSIVE
+   ============================================ */
+@media (max-width: 768px) {
+  .hide-mobile {
+    display: none;
+  }
+  
+  .stat-card {
+    padding: 1rem;
+  }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -52,7 +52,9 @@ import { toast } from "@/hooks/use-toast"
 import { buildApiPath, readApiJsonOrText } from "@/lib/api-client"
 
 // ============================================
-// ELITE CRM - MODERN OCEAN THEME
+// KING CRM HUB - ELITE DASHBOARD
+// Cream background with cobalt accents
+// Matching landing page aesthetic
 // ============================================
 
 // Mock Data - fixed ISO dates to avoid hydration mismatch
@@ -361,11 +363,11 @@ function DashboardView() {
   const visibleActivities = activities.length > 0 ? activities.slice(0, 5) : mockActivities.slice(0, 5)
 
   return (
-    <div className="p-6 space-y-6 bg-[#F5F7FB] min-h-screen">
+    <div className="p-6 space-y-6 bg-[#fcf8ec] min-h-screen">
       {/* Stats Grid */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
         {statCards.map((stat) => (
-          <Card key={stat.title} className="bg-white border-[#D7DFEA] shadow-sm hover:shadow-md transition-shadow card-hover">
+          <Card key={stat.title} className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] shadow-sm hover:shadow-md transition-shadow card-hover">
             <CardContent className="p-5">
               <div className="flex items-start justify-between">
                 <div>
@@ -400,7 +402,7 @@ function DashboardView() {
       {/* Charts Row */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         {/* Revenue Chart */}
-        <Card className="lg:col-span-2 bg-white border-[#D7DFEA] shadow-sm">
+        <Card className="lg:col-span-2 bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] shadow-sm">
           <CardHeader>
             <CardTitle className="text-black">Revenue & Leads</CardTitle>
             <CardDescription className="text-gray-500">Monthly performance overview</CardDescription>
@@ -430,7 +432,7 @@ function DashboardView() {
         </Card>
         
         {/* Lead Sources */}
-        <Card className="bg-white border-[#D7DFEA] shadow-sm">
+        <Card className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] shadow-sm">
           <CardHeader>
             <CardTitle className="text-black">Lead Sources</CardTitle>
             <CardDescription className="text-gray-500">Distribution by channel</CardDescription>
@@ -473,7 +475,7 @@ function DashboardView() {
       {/* AI Insights & Recent Activity */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* AI Insights */}
-        <Card className="bg-white border-[#D7DFEA] shadow-sm">
+        <Card className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] shadow-sm">
           <CardHeader>
             <div className="flex items-center gap-2">
               <Sparkles className="w-5 h-5 text-[#2563EB]" />
@@ -538,7 +540,7 @@ function DashboardView() {
         </Card>
         
         {/* Recent Activity */}
-        <Card className="bg-white border-[#D7DFEA] shadow-sm">
+        <Card className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] shadow-sm">
           <CardHeader>
             <div className="flex items-center gap-2">
               <Activity className="w-5 h-5 text-[#2563EB]" />
@@ -570,7 +572,7 @@ function DashboardView() {
       </div>
 
       {myDay && (
-        <Card className="bg-white border-[#D7DFEA] shadow-sm">
+        <Card className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] shadow-sm">
           <CardHeader>
             <div className="flex items-center gap-2">
               <Bot className="w-5 h-5 text-[#2563EB]" />
@@ -583,7 +585,7 @@ function DashboardView() {
               <h4 className="text-sm font-semibold text-black mb-3">Priority Leads to Call</h4>
               <div className="space-y-2">
                 {myDay.leadsToCall.slice(0, 5).map((lead) => (
-                  <div key={lead.id} className="p-3 bg-[#EEF2F7] rounded-lg border border-[#D7DFEA]">
+                  <div key={lead.id} className="p-3 bg-[#EEF2F7] rounded-lg border border-[rgba(31,42,54,0.08)]">
                     <p className="text-sm font-medium text-black">{lead.name}</p>
                     <p className="text-xs text-gray-500">{lead.company || 'Unknown company'}</p>
                     <div className="flex items-center justify-between mt-2">
@@ -598,11 +600,11 @@ function DashboardView() {
               <h4 className="text-sm font-semibold text-black mb-3">Upcoming Meetings</h4>
               <div className="space-y-2">
                 {myDay.meetings.length === 0 ? (
-                  <div className="p-3 bg-[#EEF2F7] rounded-lg border border-[#D7DFEA] text-sm text-gray-500">
+                  <div className="p-3 bg-[#EEF2F7] rounded-lg border border-[rgba(31,42,54,0.08)] text-sm text-gray-500">
                     No meetings queued yet.
                   </div>
                 ) : myDay.meetings.slice(0, 5).map((meeting) => (
-                  <div key={meeting.id} className="p-3 bg-[#EEF2F7] rounded-lg border border-[#D7DFEA]">
+                  <div key={meeting.id} className="p-3 bg-[#EEF2F7] rounded-lg border border-[rgba(31,42,54,0.08)]">
                     <p className="text-sm font-medium text-black">{meeting.title}</p>
                     <p className="text-xs text-gray-500">{meeting.lead?.name || 'Unassigned lead'}</p>
                     <p className="text-xs text-gray-500 mt-1">{new Date(meeting.time).toLocaleString()}</p>
@@ -932,7 +934,7 @@ function LeadsView({ onAddLead, onUploadCSV, onScrape, refreshKey = 0 }: { onAdd
   }
 
   return (
-    <div className="p-6 space-y-6 bg-[#F5F7FB] min-h-screen">
+    <div className="p-6 space-y-6 bg-[#fcf8ec] min-h-screen">
       {/* Header with Add new lead + Import CSV on tab */}
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
         <div>
@@ -968,10 +970,10 @@ function LeadsView({ onAddLead, onUploadCSV, onScrape, refreshKey = 0 }: { onAdd
         <div className="flex items-center gap-2">
           <Filter className="w-4 h-4 text-gray-400" />
           <Select value={filterStatus} onValueChange={setFilterStatus}>
-            <SelectTrigger className="w-[140px] bg-white border-[#D7DFEA]">
+            <SelectTrigger className="w-[140px] bg-[#fcfcfc] border-[rgba(31,42,54,0.08)]">
               <SelectValue placeholder="Filter by status" />
             </SelectTrigger>
-            <SelectContent className="bg-white border-[#D7DFEA]">
+            <SelectContent className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)]">
               <SelectItem value="all">All Status</SelectItem>
               <SelectItem value="new">New</SelectItem>
               <SelectItem value="qualified">Qualified</SelectItem>
@@ -982,10 +984,10 @@ function LeadsView({ onAddLead, onUploadCSV, onScrape, refreshKey = 0 }: { onAdd
           </Select>
         </div>
         <Select value={sortBy} onValueChange={setSortBy}>
-          <SelectTrigger className="w-[140px] bg-white border-[#D7DFEA]">
+          <SelectTrigger className="w-[140px] bg-[#fcfcfc] border-[rgba(31,42,54,0.08)]">
             <SelectValue placeholder="Sort by" />
           </SelectTrigger>
-          <SelectContent className="bg-white border-[#D7DFEA]">
+          <SelectContent className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)]">
             <SelectItem value="score">AI Score</SelectItem>
             <SelectItem value="value">Value</SelectItem>
             <SelectItem value="date">Date Added</SelectItem>
@@ -994,7 +996,7 @@ function LeadsView({ onAddLead, onUploadCSV, onScrape, refreshKey = 0 }: { onAdd
       </div>
       
       {/* Leads Table */}
-      <Card className="bg-white border-[#D7DFEA] shadow-sm overflow-hidden">
+      <Card className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] shadow-sm overflow-hidden">
         {error && (
           <div className="p-4 bg-amber-50 border-b border-amber-200 text-amber-800 text-sm">{error}</div>
         )}
@@ -1004,7 +1006,7 @@ function LeadsView({ onAddLead, onUploadCSV, onScrape, refreshKey = 0 }: { onAdd
           <div className="overflow-x-auto">
           <table className="w-full">
             <thead>
-              <tr className="border-b border-[#D7DFEA] bg-[#EEF2F7]">
+              <tr className="border-b border-[rgba(31,42,54,0.08)] bg-[#EEF2F7]">
                 <th className="text-left p-4 text-sm font-medium text-gray-600">Contact</th>
                 <th className="text-left p-4 text-sm font-medium text-gray-600">Company</th>
                 <th className="text-left p-4 text-sm font-medium text-gray-600">Source</th>
@@ -1023,7 +1025,7 @@ function LeadsView({ onAddLead, onUploadCSV, onScrape, refreshKey = 0 }: { onAdd
                   key={lead.id}
                   initial={{ opacity: 0 }}
                   animate={{ opacity: 1 }}
-                  className="border-b border-[#D7DFEA] hover:bg-[#F5F7FB] transition-colors cursor-pointer"
+                  className="border-b border-[rgba(31,42,54,0.08)] hover:bg-[#fcf8ec] transition-colors cursor-pointer"
                   onClick={() => setSelectedLead(lead)}
                 >
                   <td className="p-4">
@@ -1044,7 +1046,7 @@ function LeadsView({ onAddLead, onUploadCSV, onScrape, refreshKey = 0 }: { onAdd
                     <p className="text-xs text-gray-500">{lead.title}</p>
                   </td>
                   <td className="p-4">
-                    <Badge variant="outline" className="capitalize border-[#D7DFEA] text-gray-600">
+                    <Badge variant="outline" className="capitalize border-[rgba(31,42,54,0.08)] text-gray-600">
                       {lead.source}
                     </Badge>
                   </td>
@@ -1123,7 +1125,7 @@ function LeadsView({ onAddLead, onUploadCSV, onScrape, refreshKey = 0 }: { onAdd
           setAssistantSaving(false)
         }}
       >
-        <DialogContent className="bg-white border-[#D7DFEA] max-w-2xl">
+        <DialogContent className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] max-w-2xl">
           {selectedLead && (
             <>
               <DialogHeader>
@@ -1178,7 +1180,7 @@ function LeadsView({ onAddLead, onUploadCSV, onScrape, refreshKey = 0 }: { onAdd
                 </div>
               </div>
 
-              <Card className="bg-[#F5F7FB] border-[#D7DFEA]">
+              <Card className="bg-[#fcf8ec] border-[rgba(31,42,54,0.08)]">
                 <CardHeader className="pb-3">
                   <CardTitle className="text-base flex items-center gap-2 text-black">
                     <Bot className="w-4 h-4 text-[#2563EB]" />
@@ -1208,13 +1210,13 @@ function LeadsView({ onAddLead, onUploadCSV, onScrape, refreshKey = 0 }: { onAdd
                       )}
                     </Button>
                     {assistantSource && (
-                      <Badge variant="outline" className="border-[#D7DFEA] text-gray-600 capitalize">
+                      <Badge variant="outline" className="border-[rgba(31,42,54,0.08)] text-gray-600 capitalize">
                         Source: {assistantSource}
                       </Badge>
                     )}
                     <Button
                       variant="outline"
-                      className="border-[#D7DFEA] text-gray-700 hover:bg-[#EEF2F7]"
+                      className="border-[rgba(31,42,54,0.08)] text-gray-700 hover:bg-[#EEF2F7]"
                       disabled={!assistantPlaybook || assistantSaving}
                       onClick={() => void savePlaybookToTimeline(selectedLead.id)}
                     >
@@ -1224,7 +1226,7 @@ function LeadsView({ onAddLead, onUploadCSV, onScrape, refreshKey = 0 }: { onAdd
 
                   {assistantPlaybook && (
                     <div className="space-y-4">
-                      <div className="rounded-lg border border-[#D7DFEA] bg-white p-4">
+                      <div className="rounded-lg border border-[rgba(31,42,54,0.08)] bg-white p-4">
                         <p className="text-xs text-gray-500">Recommended Carrier</p>
                         <p className="text-sm font-semibold text-black mt-1">
                           {assistantPlaybook.recommendedCarrier.name}
@@ -1243,7 +1245,7 @@ function LeadsView({ onAddLead, onUploadCSV, onScrape, refreshKey = 0 }: { onAdd
                           <p className="text-xs text-gray-500 mb-2">Backup Carriers</p>
                           <div className="space-y-2">
                             {assistantPlaybook.backupCarriers.map((carrier, idx) => (
-                              <div key={`${carrier.name}-${idx}`} className="rounded-lg border border-[#D7DFEA] bg-white p-3">
+                              <div key={`${carrier.name}-${idx}`} className="rounded-lg border border-[rgba(31,42,54,0.08)] bg-white p-3">
                                 <p className="text-sm font-medium text-black">{carrier.name}</p>
                                 <p className="text-xs text-gray-600 mt-1">{carrier.rationale}</p>
                               </div>
@@ -1253,7 +1255,7 @@ function LeadsView({ onAddLead, onUploadCSV, onScrape, refreshKey = 0 }: { onAdd
                       )}
 
                       <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-                        <div className="rounded-lg border border-[#D7DFEA] bg-white p-3">
+                        <div className="rounded-lg border border-[rgba(31,42,54,0.08)] bg-white p-3">
                           <p className="text-xs text-gray-500 mb-2">Qualification Summary</p>
                           <ul className="text-sm text-gray-700 space-y-1">
                             {assistantPlaybook.qualificationSummary.map((item, idx) => (
@@ -1261,7 +1263,7 @@ function LeadsView({ onAddLead, onUploadCSV, onScrape, refreshKey = 0 }: { onAdd
                             ))}
                           </ul>
                         </div>
-                        <div className="rounded-lg border border-[#D7DFEA] bg-white p-3">
+                        <div className="rounded-lg border border-[rgba(31,42,54,0.08)] bg-white p-3">
                           <p className="text-xs text-gray-500 mb-2">Objection Handling</p>
                           <ul className="text-sm text-gray-700 space-y-1">
                             {assistantPlaybook.objectionHandling.map((item, idx) => (
@@ -1271,7 +1273,7 @@ function LeadsView({ onAddLead, onUploadCSV, onScrape, refreshKey = 0 }: { onAdd
                         </div>
                       </div>
 
-                      <div className="rounded-lg border border-[#D7DFEA] bg-white p-3 space-y-2">
+                      <div className="rounded-lg border border-[rgba(31,42,54,0.08)] bg-white p-3 space-y-2">
                         <p className="text-xs text-gray-500">Follow-up Scripts</p>
                         <p className="text-sm text-gray-700"><span className="font-medium text-black">Call opening:</span> {assistantPlaybook.followUpScripts.callOpening}</p>
                         <p className="text-sm text-gray-700"><span className="font-medium text-black">SMS:</span> {assistantPlaybook.followUpScripts.sms}</p>
@@ -1280,10 +1282,10 @@ function LeadsView({ onAddLead, onUploadCSV, onScrape, refreshKey = 0 }: { onAdd
                       </div>
 
                       {assistantPlaybook.citations?.length > 0 && (
-                        <div className="rounded-lg border border-[#D7DFEA] bg-white p-3 space-y-2">
+                        <div className="rounded-lg border border-[rgba(31,42,54,0.08)] bg-white p-3 space-y-2">
                           <p className="text-xs text-gray-500">Grounding Citations</p>
                           {assistantPlaybook.citations.slice(0, 4).map((c, idx) => (
-                            <div key={`${c.documentId}-${c.chunkIndex}-${idx}`} className="rounded border border-[#E6EDF7] bg-[#F5F7FB] p-2">
+                            <div key={`${c.documentId}-${c.chunkIndex}-${idx}`} className="rounded border border-[#E6EDF7] bg-[#fcf8ec] p-2">
                               <p className="text-xs font-medium text-black">
                                 {c.carrierName} - {c.documentName} (chunk {c.chunkIndex})
                               </p>
@@ -1300,7 +1302,7 @@ function LeadsView({ onAddLead, onUploadCSV, onScrape, refreshKey = 0 }: { onAdd
               <div className="flex justify-end gap-3">
                 <Button
                   variant="outline"
-                  className="border-[#D7DFEA] text-black hover:bg-[#EEF2F7]"
+                  className="border-[rgba(31,42,54,0.08)] text-black hover:bg-[#EEF2F7]"
                   onClick={openEditLead}
                 >
                   <Edit className="w-4 h-4 mr-2" />
@@ -1342,7 +1344,7 @@ function LeadsView({ onAddLead, onUploadCSV, onScrape, refreshKey = 0 }: { onAdd
       </Dialog>
 
       <Dialog open={showEditLeadDialog} onOpenChange={setShowEditLeadDialog}>
-        <DialogContent className="bg-white border-[#D7DFEA] max-w-2xl">
+        <DialogContent className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] max-w-2xl">
           <DialogHeader>
             <DialogTitle className="text-black">Edit Lead</DialogTitle>
             <DialogDescription>Update the lead’s CRM profile and workflow status.</DialogDescription>
@@ -1350,36 +1352,36 @@ function LeadsView({ onAddLead, onUploadCSV, onScrape, refreshKey = 0 }: { onAdd
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
               <Label className="text-gray-600">First name</Label>
-              <Input className="mt-1 bg-[#EEF2F7] border-[#D7DFEA]" value={editLeadForm.firstName} onChange={(e) => setEditLeadForm((prev) => ({ ...prev, firstName: e.target.value }))} />
+              <Input className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" value={editLeadForm.firstName} onChange={(e) => setEditLeadForm((prev) => ({ ...prev, firstName: e.target.value }))} />
             </div>
             <div>
               <Label className="text-gray-600">Last name</Label>
-              <Input className="mt-1 bg-[#EEF2F7] border-[#D7DFEA]" value={editLeadForm.lastName} onChange={(e) => setEditLeadForm((prev) => ({ ...prev, lastName: e.target.value }))} />
+              <Input className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" value={editLeadForm.lastName} onChange={(e) => setEditLeadForm((prev) => ({ ...prev, lastName: e.target.value }))} />
             </div>
             <div>
               <Label className="text-gray-600">Email</Label>
-              <Input className="mt-1 bg-[#EEF2F7] border-[#D7DFEA]" type="email" value={editLeadForm.email} onChange={(e) => setEditLeadForm((prev) => ({ ...prev, email: e.target.value }))} />
+              <Input className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" type="email" value={editLeadForm.email} onChange={(e) => setEditLeadForm((prev) => ({ ...prev, email: e.target.value }))} />
             </div>
             <div>
               <Label className="text-gray-600">Phone</Label>
-              <Input className="mt-1 bg-[#EEF2F7] border-[#D7DFEA]" value={editLeadForm.phone} onChange={(e) => setEditLeadForm((prev) => ({ ...prev, phone: e.target.value }))} />
+              <Input className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" value={editLeadForm.phone} onChange={(e) => setEditLeadForm((prev) => ({ ...prev, phone: e.target.value }))} />
             </div>
             <div>
               <Label className="text-gray-600">Company</Label>
-              <Input className="mt-1 bg-[#EEF2F7] border-[#D7DFEA]" value={editLeadForm.company} onChange={(e) => setEditLeadForm((prev) => ({ ...prev, company: e.target.value }))} />
+              <Input className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" value={editLeadForm.company} onChange={(e) => setEditLeadForm((prev) => ({ ...prev, company: e.target.value }))} />
             </div>
             <div>
               <Label className="text-gray-600">Title</Label>
-              <Input className="mt-1 bg-[#EEF2F7] border-[#D7DFEA]" value={editLeadForm.title} onChange={(e) => setEditLeadForm((prev) => ({ ...prev, title: e.target.value }))} />
+              <Input className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" value={editLeadForm.title} onChange={(e) => setEditLeadForm((prev) => ({ ...prev, title: e.target.value }))} />
             </div>
             <div>
               <Label className="text-gray-600">Source</Label>
-              <Input className="mt-1 bg-[#EEF2F7] border-[#D7DFEA]" value={editLeadForm.source} onChange={(e) => setEditLeadForm((prev) => ({ ...prev, source: e.target.value }))} />
+              <Input className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" value={editLeadForm.source} onChange={(e) => setEditLeadForm((prev) => ({ ...prev, source: e.target.value }))} />
             </div>
             <div>
               <Label className="text-gray-600">Status</Label>
               <Select value={editLeadForm.status} onValueChange={(value) => setEditLeadForm((prev) => ({ ...prev, status: value }))}>
-                <SelectTrigger className="mt-1 bg-[#EEF2F7] border-[#D7DFEA]"><SelectValue /></SelectTrigger>
+                <SelectTrigger className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]"><SelectValue /></SelectTrigger>
                 <SelectContent>
                   <SelectItem value="new">New</SelectItem>
                   <SelectItem value="contacted">Contacted</SelectItem>
@@ -1393,22 +1395,22 @@ function LeadsView({ onAddLead, onUploadCSV, onScrape, refreshKey = 0 }: { onAdd
             </div>
             <div>
               <Label className="text-gray-600">Estimated value</Label>
-              <Input className="mt-1 bg-[#EEF2F7] border-[#D7DFEA]" type="number" value={editLeadForm.estimatedValue} onChange={(e) => setEditLeadForm((prev) => ({ ...prev, estimatedValue: e.target.value }))} />
+              <Input className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" type="number" value={editLeadForm.estimatedValue} onChange={(e) => setEditLeadForm((prev) => ({ ...prev, estimatedValue: e.target.value }))} />
             </div>
             <div className="md:col-span-2">
               <Label className="text-gray-600">AI next action</Label>
-              <Textarea className="mt-1 bg-[#EEF2F7] border-[#D7DFEA]" value={editLeadForm.aiNextAction} onChange={(e) => setEditLeadForm((prev) => ({ ...prev, aiNextAction: e.target.value }))} />
+              <Textarea className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" value={editLeadForm.aiNextAction} onChange={(e) => setEditLeadForm((prev) => ({ ...prev, aiNextAction: e.target.value }))} />
             </div>
           </div>
           <DialogFooter>
-            <Button variant="outline" className="border-[#D7DFEA]" onClick={() => setShowEditLeadDialog(false)}>Cancel</Button>
+            <Button variant="outline" className="border-[rgba(31,42,54,0.08)]" onClick={() => setShowEditLeadDialog(false)}>Cancel</Button>
             <Button className="btn-gold" onClick={() => void saveLeadEdits()}>Save lead</Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
 
       <Dialog open={showContactLeadDialog} onOpenChange={setShowContactLeadDialog}>
-        <DialogContent className="bg-white border-[#D7DFEA]">
+        <DialogContent className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)]">
           <DialogHeader>
             <DialogTitle className="text-black">Contact Lead</DialogTitle>
             <DialogDescription>Send or record an SMS follow-up for this lead.</DialogDescription>
@@ -1416,15 +1418,15 @@ function LeadsView({ onAddLead, onUploadCSV, onScrape, refreshKey = 0 }: { onAdd
           <div className="space-y-3">
             <div>
               <Label className="text-gray-600">To</Label>
-              <Input className="mt-1 bg-[#EEF2F7] border-[#D7DFEA]" value={selectedLead?.phone || ''} readOnly />
+              <Input className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" value={selectedLead?.phone || ''} readOnly />
             </div>
             <div>
               <Label className="text-gray-600">Message</Label>
-              <Textarea className="mt-1 min-h-28 bg-[#EEF2F7] border-[#D7DFEA]" value={contactMessage} onChange={(e) => setContactMessage(e.target.value)} />
+              <Textarea className="mt-1 min-h-28 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" value={contactMessage} onChange={(e) => setContactMessage(e.target.value)} />
             </div>
           </div>
           <DialogFooter>
-            <Button variant="outline" className="border-[#D7DFEA]" onClick={() => setShowContactLeadDialog(false)}>Cancel</Button>
+            <Button variant="outline" className="border-[rgba(31,42,54,0.08)]" onClick={() => setShowContactLeadDialog(false)}>Cancel</Button>
             <Button className="btn-gold" onClick={() => void sendLeadMessage()}>Send message</Button>
           </DialogFooter>
         </DialogContent>
@@ -1445,7 +1447,7 @@ function SortableItem({ item }: { item: PipelineItem }) {
   
   return (
     <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
-      <Card className="bg-white border-[#D7DFEA] hover:border-[#2563EB] cursor-grab active:cursor-grabbing mb-2 shadow-sm">
+      <Card className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] hover:border-[#2563EB] cursor-grab active:cursor-grabbing mb-2 shadow-sm">
         <CardContent className="p-3">
           <div className="flex items-start justify-between mb-2">
             <h4 className="text-sm font-medium text-black truncate flex-1">{item.title}</h4>
@@ -1489,7 +1491,7 @@ function PipelineStageColumn({
       ref={setNodeRef}
       className={cn(
         "shrink-0 w-[300px] bg-white rounded-lg border shadow-sm transition-colors",
-        isOver ? "border-[#2563EB] bg-[#EFF6FF]" : "border-[#D7DFEA]"
+        isOver ? "border-[#2563EB] bg-[#EFF6FF]" : "border-[rgba(31,42,54,0.08)]"
       )}
     >
       {children}
@@ -1592,7 +1594,7 @@ function PipelineView() {
   )
   
   return (
-    <div className="p-6 space-y-6 bg-[#F5F7FB] min-h-screen">
+    <div className="p-6 space-y-6 bg-[#fcf8ec] min-h-screen">
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
         <div>
@@ -1600,7 +1602,7 @@ function PipelineView() {
           <p className="text-gray-500">Drag and drop deals through your sales stages</p>
         </div>
         <div className="flex items-center gap-4">
-          <Card className="bg-white border-[#D7DFEA] px-4 py-2 shadow-sm">
+          <Card className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] px-4 py-2 shadow-sm">
             <div className="flex items-center gap-2">
               <DollarSign className="w-4 h-4 text-[#2563EB]" />
               <span className="text-lg font-semibold text-black">${totalValue.toLocaleString()}</span>
@@ -1628,7 +1630,7 @@ function PipelineView() {
                 <PipelineStageColumn key={stage.id} stage={stage}>
                   {/* Column Header */}
                   <div
-                    className="p-3 border-b border-[#D7DFEA] flex items-center justify-between"
+                    className="p-3 border-b border-[rgba(31,42,54,0.08)] flex items-center justify-between"
                     style={{ borderTopLeftRadius: 8, borderTopRightRadius: 8, borderTop: `3px solid ${stage.color}` }}
                   >
                     <div className="flex items-center gap-2">
@@ -1745,7 +1747,7 @@ function UploadsView({ onUploadCSV, refreshKey = 0 }: { onUploadCSV: () => void;
   }, [refreshKey])
 
   return (
-    <div className="p-6 space-y-6 bg-[#F5F7FB] min-h-screen">
+    <div className="p-6 space-y-6 bg-[#fcf8ec] min-h-screen">
       {/* Header with Upload NEW CSV on tab */}
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
         <div>
@@ -1773,7 +1775,7 @@ function UploadsView({ onUploadCSV, refreshKey = 0 }: { onUploadCSV: () => void;
       )}
 
       {!loading && !error && uploads.length === 0 && (
-        <Card className="bg-white border-[#D7DFEA]">
+        <Card className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)]">
           <CardContent className="p-12 text-center">
             <FileSpreadsheet className="w-12 h-12 text-[#2563EB]/60 mx-auto mb-4" />
             <p className="text-gray-600">No uploads yet. Import leads from a CSV to see history here.</p>
@@ -1789,7 +1791,7 @@ function UploadsView({ onUploadCSV, refreshKey = 0 }: { onUploadCSV: () => void;
       {!loading && uploads.length > 0 && (
       <div className="space-y-4">
         {uploads.map((upload) => (
-          <Card key={upload.id} className="bg-white border-[#D7DFEA] shadow-sm">
+          <Card key={upload.id} className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] shadow-sm">
             <CardContent className="p-5">
               <div className="flex items-start justify-between">
                 <div className="flex items-start gap-4">
@@ -1921,12 +1923,12 @@ function LinearView({ onCreateIssue }: { onCreateIssue: () => void }) {
 
   if (!configured) {
     return (
-      <div className="p-6 space-y-6 bg-[#F5F7FB] min-h-screen">
+      <div className="p-6 space-y-6 bg-[#fcf8ec] min-h-screen">
         <div>
           <h1 className="text-2xl font-bold text-black">Linear Integration</h1>
           <p className="text-gray-500">Connect your Linear workspace to sync issues</p>
         </div>
-        <Card className="bg-white border-[#D7DFEA] shadow-sm">
+        <Card className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] shadow-sm">
           <CardContent className="p-8 text-center space-y-4">
             <div className="w-16 h-16 rounded-2xl bg-[#5E6AD2]/10 flex items-center justify-center mx-auto">
               <SquareKanban className="w-8 h-8 text-[#5E6AD2]" />
@@ -1947,7 +1949,7 @@ function LinearView({ onCreateIssue }: { onCreateIssue: () => void }) {
   }
 
   return (
-    <div className="p-6 space-y-6 bg-[#F5F7FB] min-h-screen">
+    <div className="p-6 space-y-6 bg-[#fcf8ec] min-h-screen">
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
         <div>
           <h1 className="text-2xl font-bold text-black flex items-center gap-2">
@@ -1959,7 +1961,7 @@ function LinearView({ onCreateIssue }: { onCreateIssue: () => void }) {
         <div className="flex items-center gap-3">
           <Button
             variant="outline"
-            className="border-[#D7DFEA] text-gray-600 hover:bg-[#EEF2F7] gap-2"
+            className="border-[rgba(31,42,54,0.08)] text-gray-600 hover:bg-[#EEF2F7] gap-2"
             onClick={fetchData}
             disabled={loading}
           >
@@ -1981,7 +1983,7 @@ function LinearView({ onCreateIssue }: { onCreateIssue: () => void }) {
           { title: "Urgent/High", value: issues.filter(i => i.priority <= 2 && i.priority > 0).length, icon: AlertTriangle, color: "#DC2626" },
           { title: "Teams", value: teams.length, icon: Users, color: "#059669" },
         ].map((stat) => (
-          <Card key={stat.title} className="bg-white border-[#D7DFEA] shadow-sm">
+          <Card key={stat.title} className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] shadow-sm">
             <CardContent className="p-4">
               <div className="flex items-center gap-3">
                 <div className="w-10 h-10 rounded-lg flex items-center justify-center" style={{ backgroundColor: `${stat.color}15` }}>
@@ -2002,10 +2004,10 @@ function LinearView({ onCreateIssue }: { onCreateIssue: () => void }) {
         <div className="flex items-center gap-2">
           <Filter className="w-4 h-4 text-gray-400" />
           <Select value={selectedTeam} onValueChange={setSelectedTeam}>
-            <SelectTrigger className="w-[180px] bg-white border-[#D7DFEA]">
+            <SelectTrigger className="w-[180px] bg-[#fcfcfc] border-[rgba(31,42,54,0.08)]">
               <SelectValue placeholder="Filter by team" />
             </SelectTrigger>
-            <SelectContent className="bg-white border-[#D7DFEA]">
+            <SelectContent className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)]">
               <SelectItem value="all">All Teams</SelectItem>
               {teams.map((t) => (
                 <SelectItem key={t.id} value={t.id}>{t.name} ({t.key})</SelectItem>
@@ -2022,14 +2024,14 @@ function LinearView({ onCreateIssue }: { onCreateIssue: () => void }) {
         </Card>
       )}
 
-      <Card className="bg-white border-[#D7DFEA] shadow-sm overflow-hidden">
+      <Card className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] shadow-sm overflow-hidden">
         {loading ? (
           <div className="p-8 text-center text-gray-500">Loading issues from Linear...</div>
         ) : (
           <div className="overflow-x-auto">
             <table className="w-full">
               <thead>
-                <tr className="border-b border-[#D7DFEA] bg-[#EEF2F7]">
+                <tr className="border-b border-[rgba(31,42,54,0.08)] bg-[#EEF2F7]">
                   <th className="text-left p-4 text-sm font-medium text-gray-600">Issue</th>
                   <th className="text-left p-4 text-sm font-medium text-gray-600">Status</th>
                   <th className="text-left p-4 text-sm font-medium text-gray-600">Priority</th>
@@ -2054,7 +2056,7 @@ function LinearView({ onCreateIssue }: { onCreateIssue: () => void }) {
                         key={issue.id}
                         initial={{ opacity: 0 }}
                         animate={{ opacity: 1 }}
-                        className="border-b border-[#D7DFEA] hover:bg-[#F5F7FB] transition-colors cursor-pointer"
+                        className="border-b border-[rgba(31,42,54,0.08)] hover:bg-[#fcf8ec] transition-colors cursor-pointer"
                         onClick={() => setSelectedIssue(issue)}
                       >
                         <td className="p-4">
@@ -2062,7 +2064,7 @@ function LinearView({ onCreateIssue }: { onCreateIssue: () => void }) {
                             <div className="flex items-center gap-2">
                               <span className="text-xs font-mono text-gray-400">{issue.identifier}</span>
                               {issue.team && (
-                                <Badge variant="outline" className="text-xs border-[#D7DFEA] text-gray-500">{issue.team.key}</Badge>
+                                <Badge variant="outline" className="text-xs border-[rgba(31,42,54,0.08)] text-gray-500">{issue.team.key}</Badge>
                               )}
                             </div>
                             <p className="text-sm font-medium text-black mt-0.5 max-w-[300px] truncate">{issue.title}</p>
@@ -2136,14 +2138,14 @@ function LinearView({ onCreateIssue }: { onCreateIssue: () => void }) {
 
       {/* Issue detail modal */}
       <Dialog open={!!selectedIssue} onOpenChange={() => setSelectedIssue(null)}>
-        <DialogContent className="bg-white border-[#D7DFEA] max-w-2xl">
+        <DialogContent className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] max-w-2xl">
           {selectedIssue && (
             <>
               <DialogHeader>
                 <div className="flex items-center gap-2 text-sm text-gray-400 font-mono">
                   {selectedIssue.identifier}
                   {selectedIssue.team && (
-                    <Badge variant="outline" className="text-xs border-[#D7DFEA]">{selectedIssue.team.name}</Badge>
+                    <Badge variant="outline" className="text-xs border-[rgba(31,42,54,0.08)]">{selectedIssue.team.name}</Badge>
                   )}
                 </div>
                 <DialogTitle className="text-xl text-black">{selectedIssue.title}</DialogTitle>
@@ -2339,7 +2341,7 @@ function AutomationView() {
   const activeCount = automations.filter((automation) => automation.isActive).length
 
   return (
-    <div className="p-6 space-y-6 bg-[#F5F7FB] min-h-screen">
+    <div className="p-6 space-y-6 bg-[#fcf8ec] min-h-screen">
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold text-black">AI Automation</h1>
@@ -2360,7 +2362,7 @@ function AutomationView() {
           { title: "Total Automations", value: automations.length, icon: Activity },
           { title: "Runs Logged", value: automations.reduce((total, automation) => total + automation.executionCount, 0), icon: Brain },
         ].map((stat) => (
-          <Card key={stat.title} className="bg-white border-[#D7DFEA] shadow-sm">
+          <Card key={stat.title} className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] shadow-sm">
             <CardContent className="p-4">
               <div className="flex items-center gap-3">
                 <div className="w-10 h-10 rounded-lg bg-[#2563EB]/20 flex items-center justify-center">
@@ -2376,7 +2378,7 @@ function AutomationView() {
         ))}
       </div>
 
-      <Card className="bg-white border-[#D7DFEA] shadow-sm">
+      <Card className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] shadow-sm">
         <CardHeader>
           <CardTitle className="text-black">Automation Library</CardTitle>
           <CardDescription>Lead-triggered workflows that run inside your CRM organization.</CardDescription>
@@ -2385,13 +2387,13 @@ function AutomationView() {
           {loading ? (
             <div className="text-sm text-gray-500">Loading automations…</div>
           ) : automations.length === 0 ? (
-            <div className="rounded-lg border border-dashed border-[#D7DFEA] p-6 text-sm text-gray-500">
+            <div className="rounded-lg border border-dashed border-[rgba(31,42,54,0.08)] p-6 text-sm text-gray-500">
               No automations yet. Create a workflow for new leads, stage changes, or follow-up reminders.
             </div>
           ) : (
             <div className="space-y-3">
               {automations.map((automation) => (
-                <div key={automation.id} className="rounded-lg border border-[#D7DFEA] bg-[#EEF2F7] p-4 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+                <div key={automation.id} className="rounded-lg border border-[rgba(31,42,54,0.08)] bg-[#EEF2F7] p-4 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
                   <div className="min-w-0">
                     <div className="flex items-center gap-2">
                       <p className="text-sm font-semibold text-black">{automation.name}</p>
@@ -2410,7 +2412,7 @@ function AutomationView() {
                   </div>
                   <div className="flex items-center gap-2">
                     <Switch checked={automation.isActive} onCheckedChange={(checked) => void updateAutomation(automation.id, { isActive: checked })} />
-                    <Button variant="outline" className="border-[#D7DFEA]" onClick={() => void deleteAutomation(automation.id)}>
+                    <Button variant="outline" className="border-[rgba(31,42,54,0.08)]" onClick={() => void deleteAutomation(automation.id)}>
                       Delete
                     </Button>
                   </div>
@@ -2422,7 +2424,7 @@ function AutomationView() {
       </Card>
 
       <Dialog open={showCreateDialog} onOpenChange={setShowCreateDialog}>
-        <DialogContent className="bg-white border-[#D7DFEA]">
+        <DialogContent className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)]">
           <DialogHeader>
             <DialogTitle className="text-black">Create Automation</DialogTitle>
             <DialogDescription>Set a trigger and default action for your team workflow.</DialogDescription>
@@ -2430,16 +2432,16 @@ function AutomationView() {
           <div className="space-y-3">
             <div>
               <Label className="text-gray-600">Name</Label>
-              <Input className="mt-1 bg-[#EEF2F7] border-[#D7DFEA]" value={form.name} onChange={(e) => setForm((prev) => ({ ...prev, name: e.target.value }))} />
+              <Input className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" value={form.name} onChange={(e) => setForm((prev) => ({ ...prev, name: e.target.value }))} />
             </div>
             <div>
               <Label className="text-gray-600">Description</Label>
-              <Textarea className="mt-1 bg-[#EEF2F7] border-[#D7DFEA]" value={form.description} onChange={(e) => setForm((prev) => ({ ...prev, description: e.target.value }))} />
+              <Textarea className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" value={form.description} onChange={(e) => setForm((prev) => ({ ...prev, description: e.target.value }))} />
             </div>
             <div>
               <Label className="text-gray-600">Trigger</Label>
               <Select value={form.trigger} onValueChange={(value) => setForm((prev) => ({ ...prev, trigger: value }))}>
-                <SelectTrigger className="mt-1 bg-[#EEF2F7] border-[#D7DFEA]"><SelectValue /></SelectTrigger>
+                <SelectTrigger className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]"><SelectValue /></SelectTrigger>
                 <SelectContent>
                   <SelectItem value="lead_created">Lead created</SelectItem>
                   <SelectItem value="lead_scored">Lead scored</SelectItem>
@@ -2451,7 +2453,7 @@ function AutomationView() {
             <div>
               <Label className="text-gray-600">Action type</Label>
               <Select value={form.actionType} onValueChange={(value) => setForm((prev) => ({ ...prev, actionType: value }))}>
-                <SelectTrigger className="mt-1 bg-[#EEF2F7] border-[#D7DFEA]"><SelectValue /></SelectTrigger>
+                <SelectTrigger className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]"><SelectValue /></SelectTrigger>
                 <SelectContent>
                   <SelectItem value="create_task">Create task</SelectItem>
                   <SelectItem value="send_sms">Send SMS</SelectItem>
@@ -2462,11 +2464,11 @@ function AutomationView() {
             </div>
             <div>
               <Label className="text-gray-600">Action target</Label>
-              <Input className="mt-1 bg-[#EEF2F7] border-[#D7DFEA]" value={form.actionTarget} onChange={(e) => setForm((prev) => ({ ...prev, actionTarget: e.target.value }))} placeholder="Task text, phone, owner email, issue title..." />
+              <Input className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" value={form.actionTarget} onChange={(e) => setForm((prev) => ({ ...prev, actionTarget: e.target.value }))} placeholder="Task text, phone, owner email, issue title..." />
             </div>
           </div>
           <DialogFooter>
-            <Button variant="outline" className="border-[#D7DFEA]" onClick={() => setShowCreateDialog(false)}>Cancel</Button>
+            <Button variant="outline" className="border-[rgba(31,42,54,0.08)]" onClick={() => setShowCreateDialog(false)}>Cancel</Button>
             <Button className="btn-gold" onClick={() => void createAutomation()} disabled={saving}>
               {saving ? 'Saving...' : 'Create Automation'}
             </Button>
@@ -2802,7 +2804,7 @@ function SocialMediaView() {
   }
 
   return (
-    <div className="p-6 space-y-6 bg-[#F5F7FB] min-h-screen">
+    <div className="p-6 space-y-6 bg-[#fcf8ec] min-h-screen">
       <div className="flex flex-col lg:flex-row lg:items-center justify-between gap-4">
         <div>
           <h1 className="text-2xl font-bold text-black">Social Media</h1>
@@ -2827,7 +2829,7 @@ function SocialMediaView() {
             whileTap={{ scale: 0.99 }}
             type="button"
             onClick={() => applyCampaignPack(pack)}
-            className="text-left p-4 bg-white border border-[#D7DFEA] rounded-xl shadow-sm hover:shadow-md transition-shadow"
+            className="text-left p-4 bg-[#fcfcfc] border border-[rgba(31,42,54,0.08)] rounded-xl shadow-sm hover:shadow-md transition-shadow"
           >
             <p className="text-sm font-semibold text-black">{pack.label}</p>
             <p className="text-xs text-gray-500 mt-1">{pack.topic}</p>
@@ -2836,14 +2838,14 @@ function SocialMediaView() {
         ))}
       </div>
 
-      <Card className="bg-white border-[#D7DFEA] shadow-sm">
+      <Card className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] shadow-sm">
         <CardHeader>
           <div className="flex items-center justify-between gap-3">
             <div>
               <CardTitle className="text-black text-lg">Connected Social Accounts</CardTitle>
               <CardDescription>Store the platform identities your scheduled content can publish through.</CardDescription>
             </div>
-            <Button variant="outline" className="border-[#D7DFEA]" onClick={() => setShowSocialAccountDialog(true)}>
+            <Button variant="outline" className="border-[rgba(31,42,54,0.08)]" onClick={() => setShowSocialAccountDialog(true)}>
               <Plus className="w-4 h-4" />
               Add account
             </Button>
@@ -2851,13 +2853,13 @@ function SocialMediaView() {
         </CardHeader>
         <CardContent>
           {socialAccounts.length === 0 ? (
-            <div className="rounded-lg border border-dashed border-[#D7DFEA] p-6 text-sm text-gray-500">
+            <div className="rounded-lg border border-dashed border-[rgba(31,42,54,0.08)] p-6 text-sm text-gray-500">
               No connected accounts yet. Add LinkedIn, Facebook, Instagram, or X credentials before using automated publishing.
             </div>
           ) : (
             <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
               {socialAccounts.map((account) => (
-                <div key={account.id} className="rounded-lg border border-[#D7DFEA] bg-[#EEF2F7] p-4 space-y-3">
+                <div key={account.id} className="rounded-lg border border-[rgba(31,42,54,0.08)] bg-[#EEF2F7] p-4 space-y-3">
                   <div className="flex items-center justify-between gap-3">
                     <div>
                       <p className="text-sm font-semibold text-black capitalize">{account.platform}</p>
@@ -2873,7 +2875,7 @@ function SocialMediaView() {
                   </p>
                   <div className="flex items-center justify-between gap-2">
                     <Switch checked={account.isActive} onCheckedChange={(checked) => void toggleSocialAccount(account.id, checked)} />
-                    <Button variant="outline" className="border-[#D7DFEA]" onClick={() => void removeSocialAccount(account.id)}>
+                    <Button variant="outline" className="border-[rgba(31,42,54,0.08)]" onClick={() => void removeSocialAccount(account.id)}>
                       Remove
                     </Button>
                   </div>
@@ -2885,7 +2887,7 @@ function SocialMediaView() {
       </Card>
 
       <div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
-        <Card className="bg-white border-[#D7DFEA] shadow-sm xl:col-span-1">
+        <Card className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] shadow-sm xl:col-span-1">
           <CardHeader>
             <CardTitle className="text-black text-lg">Manual Composer</CardTitle>
             <CardDescription>Create, draft, and schedule premium brand posts.</CardDescription>
@@ -2894,7 +2896,7 @@ function SocialMediaView() {
             <div>
               <Label className="text-gray-600">Platform</Label>
               <Select value={composerPlatform} onValueChange={setComposerPlatform}>
-                <SelectTrigger className="mt-1 bg-[#EEF2F7] border-[#D7DFEA]"><SelectValue /></SelectTrigger>
+                <SelectTrigger className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]"><SelectValue /></SelectTrigger>
                 <SelectContent>
                   <SelectItem value="linkedin">LinkedIn</SelectItem>
                   <SelectItem value="twitter">Twitter/X</SelectItem>
@@ -2905,20 +2907,20 @@ function SocialMediaView() {
             </div>
             <div>
               <Label className="text-gray-600">Title</Label>
-              <Input className="mt-1 bg-[#EEF2F7] border-[#D7DFEA]" value={composerTitle} onChange={(e) => setComposerTitle(e.target.value)} placeholder="Post title (optional)" />
+              <Input className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" value={composerTitle} onChange={(e) => setComposerTitle(e.target.value)} placeholder="Post title (optional)" />
             </div>
             <div>
               <Label className="text-gray-600">Post content</Label>
-              <Textarea className="mt-1 min-h-28 bg-[#EEF2F7] border-[#D7DFEA]" value={composerContent} onChange={(e) => setComposerContent(e.target.value)} placeholder="Write a high-converting post..." />
+              <Textarea className="mt-1 min-h-28 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" value={composerContent} onChange={(e) => setComposerContent(e.target.value)} placeholder="Write a high-converting post..." />
             </div>
             <div>
               <Label className="text-gray-600">Schedule (optional)</Label>
-              <Input type="datetime-local" className="mt-1 bg-[#EEF2F7] border-[#D7DFEA]" value={composerScheduleAt} onChange={(e) => setComposerScheduleAt(e.target.value)} />
+              <Input type="datetime-local" className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" value={composerScheduleAt} onChange={(e) => setComposerScheduleAt(e.target.value)} />
             </div>
             <div className="flex gap-2">
               <Button
                 variant="outline"
-                className="flex-1 border-[#D7DFEA]"
+                className="flex-1 border-[rgba(31,42,54,0.08)]"
                 onClick={() => void saveContent({ title: composerTitle, content: composerContent, platform: composerPlatform, status: 'draft' })}
                 disabled={saving}
               >
@@ -2935,7 +2937,7 @@ function SocialMediaView() {
           </CardContent>
         </Card>
 
-        <Card className="bg-white border-[#D7DFEA] shadow-sm xl:col-span-2">
+        <Card className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] shadow-sm xl:col-span-2">
           <CardHeader>
             <div className="flex items-center justify-between gap-3">
               <div>
@@ -2943,7 +2945,7 @@ function SocialMediaView() {
                 <CardDescription>Manage drafts, scheduled posts, and published content.</CardDescription>
               </div>
               <Select value={platformFilter} onValueChange={setPlatformFilter}>
-                <SelectTrigger className="w-[180px] bg-[#EEF2F7] border-[#D7DFEA]"><SelectValue /></SelectTrigger>
+                <SelectTrigger className="w-[180px] bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]"><SelectValue /></SelectTrigger>
                 <SelectContent>
                   <SelectItem value="all">All platforms</SelectItem>
                   <SelectItem value="linkedin">LinkedIn</SelectItem>
@@ -2958,7 +2960,7 @@ function SocialMediaView() {
             {loading ? (
               <div className="py-10 text-center text-gray-500">Loading queue...</div>
             ) : filteredItems.length === 0 ? (
-              <div className="py-10 text-center text-gray-500 border border-dashed border-[#D7DFEA] rounded-lg">
+              <div className="py-10 text-center text-gray-500 border border-dashed border-[rgba(31,42,54,0.08)] rounded-lg">
                 No posts yet. Generate with AI or create your first draft.
               </div>
             ) : filteredItems.map((item) => (
@@ -2967,7 +2969,7 @@ function SocialMediaView() {
                 initial={{ opacity: 0, y: 6 }}
                 animate={{ opacity: 1, y: 0 }}
                 whileHover={{ y: -1 }}
-                className="p-4 bg-[#EEF2F7] border border-[#D7DFEA] rounded-lg"
+                className="p-4 bg-[#EEF2F7] border border-[rgba(31,42,54,0.08)] rounded-lg"
               >
                 <div className="flex items-start justify-between gap-3">
                   <div className="min-w-0">
@@ -2991,7 +2993,7 @@ function SocialMediaView() {
                       <Button
                         variant="outline"
                         size="sm"
-                        className="border-[#D7DFEA]"
+                        className="border-[rgba(31,42,54,0.08)]"
                         onClick={() => void fetch(`/api/content?id=${item.id}`, {
                           method: 'PATCH',
                           headers: { 'Content-Type': 'application/json' },
@@ -3013,7 +3015,7 @@ function SocialMediaView() {
       </div>
 
       <Dialog open={showGenerateDialog} onOpenChange={setShowGenerateDialog}>
-        <DialogContent className="bg-white border-[#D7DFEA] max-w-2xl">
+        <DialogContent className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] max-w-2xl">
           <DialogHeader>
             <DialogTitle className="text-black flex items-center gap-2"><Sparkles className="w-5 h-5 text-[#2563EB]" />Generate Social Content</DialogTitle>
             <DialogDescription>Create premium content with AI and save directly to queue.</DialogDescription>
@@ -3021,12 +3023,12 @@ function SocialMediaView() {
           <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
             <div className="md:col-span-3">
               <Label className="text-gray-600">Topic</Label>
-              <Input className="mt-1 bg-[#EEF2F7] border-[#D7DFEA]" value={topic} onChange={(e) => setTopic(e.target.value)} placeholder="Life insurance myths families should stop believing" />
+              <Input className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" value={topic} onChange={(e) => setTopic(e.target.value)} placeholder="Life insurance myths families should stop believing" />
             </div>
             <div>
               <Label className="text-gray-600">Platform</Label>
               <Select value={platform} onValueChange={setPlatform}>
-                <SelectTrigger className="mt-1 bg-[#EEF2F7] border-[#D7DFEA]"><SelectValue /></SelectTrigger>
+                <SelectTrigger className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]"><SelectValue /></SelectTrigger>
                 <SelectContent>
                   <SelectItem value="linkedin">LinkedIn</SelectItem>
                   <SelectItem value="twitter">Twitter/X</SelectItem>
@@ -3038,7 +3040,7 @@ function SocialMediaView() {
             <div>
               <Label className="text-gray-600">Tone</Label>
               <Select value={tone} onValueChange={setTone}>
-                <SelectTrigger className="mt-1 bg-[#EEF2F7] border-[#D7DFEA]"><SelectValue /></SelectTrigger>
+                <SelectTrigger className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]"><SelectValue /></SelectTrigger>
                 <SelectContent>
                   <SelectItem value="professional">Professional</SelectItem>
                   <SelectItem value="authoritative">Authoritative</SelectItem>
@@ -3057,15 +3059,15 @@ function SocialMediaView() {
           <div className="space-y-3">
             <div>
               <Label className="text-gray-600">Generated title</Label>
-              <Input className="mt-1 bg-[#EEF2F7] border-[#D7DFEA]" value={generatedTitle} onChange={(e) => setGeneratedTitle(e.target.value)} />
+              <Input className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" value={generatedTitle} onChange={(e) => setGeneratedTitle(e.target.value)} />
             </div>
             <div>
               <Label className="text-gray-600">Generated content</Label>
-              <Textarea className="mt-1 min-h-32 bg-[#EEF2F7] border-[#D7DFEA]" value={generatedContent} onChange={(e) => setGeneratedContent(e.target.value)} />
+              <Textarea className="mt-1 min-h-32 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" value={generatedContent} onChange={(e) => setGeneratedContent(e.target.value)} />
             </div>
             <div className="flex flex-wrap gap-2">
               {generatedHashtags.map((h) => (
-                <Badge key={h} variant="outline" className="border-[#D7DFEA]">{h}</Badge>
+                <Badge key={h} variant="outline" className="border-[rgba(31,42,54,0.08)]">{h}</Badge>
               ))}
             </div>
             {bestTimeToPost && <p className="text-xs text-gray-500">Best time to post: {bestTimeToPost}</p>}
@@ -3073,7 +3075,7 @@ function SocialMediaView() {
           <DialogFooter className="flex gap-2">
             <Button
               variant="outline"
-              className="border-[#D7DFEA]"
+              className="border-[rgba(31,42,54,0.08)]"
               onClick={() => void saveContent({ title: generatedTitle, content: generatedContent, platform, status: 'draft' })}
               disabled={saving}
             >
@@ -3091,7 +3093,7 @@ function SocialMediaView() {
       </Dialog>
 
       <Dialog open={showMediaDialog} onOpenChange={setShowMediaDialog}>
-        <DialogContent className="bg-white border-[#D7DFEA] max-w-xl">
+        <DialogContent className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] max-w-xl">
           <DialogHeader>
             <DialogTitle className="text-black flex items-center gap-2"><ImageIcon className="w-5 h-5 text-[#2563EB]" />Generate Media Prompt</DialogTitle>
             <DialogDescription>Create image prompts and caption/CTA for high-performing visuals.</DialogDescription>
@@ -3099,12 +3101,12 @@ function SocialMediaView() {
           <div className="space-y-3">
             <div>
               <Label className="text-gray-600">Topic</Label>
-              <Input className="mt-1 bg-[#EEF2F7] border-[#D7DFEA]" value={mediaTopic} onChange={(e) => setMediaTopic(e.target.value)} placeholder="Family life insurance peace of mind visual" />
+              <Input className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" value={mediaTopic} onChange={(e) => setMediaTopic(e.target.value)} placeholder="Family life insurance peace of mind visual" />
             </div>
             <div>
               <Label className="text-gray-600">Platform</Label>
               <Select value={mediaPlatform} onValueChange={setMediaPlatform}>
-                <SelectTrigger className="mt-1 bg-[#EEF2F7] border-[#D7DFEA]"><SelectValue /></SelectTrigger>
+                <SelectTrigger className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]"><SelectValue /></SelectTrigger>
                 <SelectContent>
                   <SelectItem value="linkedin">LinkedIn</SelectItem>
                   <SelectItem value="instagram">Instagram</SelectItem>
@@ -3118,15 +3120,15 @@ function SocialMediaView() {
             </Button>
             <div>
               <Label className="text-gray-600">Image prompt</Label>
-              <Textarea className="mt-1 min-h-24 bg-[#EEF2F7] border-[#D7DFEA]" value={mediaPrompt} onChange={(e) => setMediaPrompt(e.target.value)} />
+              <Textarea className="mt-1 min-h-24 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" value={mediaPrompt} onChange={(e) => setMediaPrompt(e.target.value)} />
             </div>
             <div>
               <Label className="text-gray-600">Caption</Label>
-              <Textarea className="mt-1 min-h-16 bg-[#EEF2F7] border-[#D7DFEA]" value={mediaCaption} onChange={(e) => setMediaCaption(e.target.value)} />
+              <Textarea className="mt-1 min-h-16 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" value={mediaCaption} onChange={(e) => setMediaCaption(e.target.value)} />
             </div>
             <div>
               <Label className="text-gray-600">CTA</Label>
-              <Input className="mt-1 bg-[#EEF2F7] border-[#D7DFEA]" value={mediaCta} onChange={(e) => setMediaCta(e.target.value)} />
+              <Input className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" value={mediaCta} onChange={(e) => setMediaCta(e.target.value)} />
             </div>
           </div>
           <DialogFooter>
@@ -3148,7 +3150,7 @@ function SocialMediaView() {
       </Dialog>
 
       <Dialog open={showSocialAccountDialog} onOpenChange={setShowSocialAccountDialog}>
-        <DialogContent className="bg-white border-[#D7DFEA]">
+        <DialogContent className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)]">
           <DialogHeader>
             <DialogTitle className="text-black">Connect Social Account</DialogTitle>
             <DialogDescription>Store the platform account details this workspace should publish through.</DialogDescription>
@@ -3157,7 +3159,7 @@ function SocialMediaView() {
             <div>
               <Label className="text-gray-600">Platform</Label>
               <Select value={socialForm.platform} onValueChange={(value) => setSocialForm((prev) => ({ ...prev, platform: value }))}>
-                <SelectTrigger className="mt-1 bg-[#EEF2F7] border-[#D7DFEA]"><SelectValue /></SelectTrigger>
+                <SelectTrigger className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]"><SelectValue /></SelectTrigger>
                 <SelectContent>
                   <SelectItem value="linkedin">LinkedIn</SelectItem>
                   <SelectItem value="twitter">Twitter / X</SelectItem>
@@ -3168,19 +3170,19 @@ function SocialMediaView() {
             </div>
             <div>
               <Label className="text-gray-600">Account ID / page ID</Label>
-              <Input className="mt-1 bg-[#EEF2F7] border-[#D7DFEA]" value={socialForm.accountId} onChange={(e) => setSocialForm((prev) => ({ ...prev, accountId: e.target.value }))} />
+              <Input className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" value={socialForm.accountId} onChange={(e) => setSocialForm((prev) => ({ ...prev, accountId: e.target.value }))} />
             </div>
             <div>
               <Label className="text-gray-600">Display name</Label>
-              <Input className="mt-1 bg-[#EEF2F7] border-[#D7DFEA]" value={socialForm.accountName} onChange={(e) => setSocialForm((prev) => ({ ...prev, accountName: e.target.value }))} />
+              <Input className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" value={socialForm.accountName} onChange={(e) => setSocialForm((prev) => ({ ...prev, accountName: e.target.value }))} />
             </div>
             <div>
               <Label className="text-gray-600">Access token</Label>
-              <Input className="mt-1 bg-[#EEF2F7] border-[#D7DFEA]" type="password" value={socialForm.accessToken} onChange={(e) => setSocialForm((prev) => ({ ...prev, accessToken: e.target.value }))} />
+              <Input className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" type="password" value={socialForm.accessToken} onChange={(e) => setSocialForm((prev) => ({ ...prev, accessToken: e.target.value }))} />
             </div>
           </div>
           <DialogFooter>
-            <Button variant="outline" className="border-[#D7DFEA]" onClick={() => setShowSocialAccountDialog(false)}>Cancel</Button>
+            <Button variant="outline" className="border-[rgba(31,42,54,0.08)]" onClick={() => setShowSocialAccountDialog(false)}>Cancel</Button>
             <Button className="btn-gold" onClick={() => void saveSocialAccount()} disabled={saving}>
               {saving ? 'Saving...' : 'Save Account'}
             </Button>
@@ -3238,7 +3240,7 @@ export default function EliteCRM() {
 
   if (authLoading) {
     return (
-      <div className="min-h-screen bg-[#F5F7FB] flex items-center justify-center text-gray-500">
+      <div className="min-h-screen bg-[#fcf8ec] flex items-center justify-center text-gray-500">
         <RefreshCw className="w-5 h-5 animate-spin mr-2" />
         Loading workspace…
       </div>


### PR DESCRIPTION
## Changes
- Unified design system across all pages
- Cream background (#fcf8ec) matching landing page
- Cobalt blue accents (#557df5) for buttons and highlights
- Updated cards, inputs, tables, and navigation
- Consistent styling throughout dashboard and auth flows
- All functionality preserved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the app on the Cream + Cobalt design system. Applies cream backgrounds (#fcf8ec) and cobalt accents (#557df5) across all views to match the landing page, with no behavior changes.

- **Refactors**
  - Replaced the old theme with a cobalt/cream palette in `globals.css` (colors, borders, shadows, charts, sidebar, focus, links, dividers, scrollbars).
  - Added utility classes: `btn-primary`, `btn-secondary`, `btn-outline`, `btn-ghost`, `card-elite`, `input-elite`, `badge-status` variants, `table-elite`, `dialog-elite`, toast styles, kanban and nav updates, and animations.
  - Updated `page.tsx` to use new backgrounds, borders, and hover colors across Dashboard, Leads, Pipeline, Uploads, Linear, Automation, and Social views.

- **Migration**
  - No API changes. Use the new tokens and utilities for new UI (e.g., `btn-primary`, `card-elite`, `table-elite`).
  - If custom components reference old theme classes or variables, switch them to the new palette for consistency.

<sup>Written for commit edf9297db6398c0cf47d3533a3e55c9ddf7f4aee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refreshed the application's design system with a new cobalt and cream color palette, replacing the previous gold/ocean theme
  * Updated visual styling across all pages and components, including buttons, cards, forms, badges, and navigation elements
  * Enhanced overall UI consistency and visual polish throughout the application

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bradywhealth-lab/kingcrmhub/pull/79)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->