### PR TITLE
feat: pricing page, onboarding wizard, upgrade banner, billing stub + onboarding migration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,8 @@ RUN npx prisma generate
 # ============================================================
 FROM node:22-alpine AS builder
 
-RUN apk add --no-cache libc6-compat python3 make g++
+# Only libc6-compat needed — native modules were compiled in deps stage
+RUN apk add --no-cache libc6-compat
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,11 @@ RUN apk add --no-cache libc6-compat python3 make g++
 
 WORKDIR /app
 
-COPY package.json package-lock.json* bun.lock* ./
+COPY package.json package-lock.json* ./
 COPY prisma ./prisma/
 
-# Install with npm ci (uses package-lock.json when present)
-# If only bun.lock is present the next line falls back gracefully
-RUN npm install --frozen-lockfile 2>/dev/null || npm install
+# Use npm ci for deterministic, lockfile-based installs
+RUN npm ci
 
 # Generate Prisma client after deps are installed
 RUN npx prisma generate
@@ -42,8 +41,8 @@ ENV NEXT_PUBLIC_SENTRY_DSN=$NEXT_PUBLIC_SENTRY_DSN
 
 # DATABASE_URL is required only at runtime (server-side Prisma),
 # but next build may call getStaticProps/generateStaticParams that touch the DB.
-# Pass a dummy value here; real value is injected at runtime via env_file.
-ARG DATABASE_URL="postgresql://placeholder:placeholder@placeholder:5432/placeholder"
+# Pass a non-credential placeholder here; real value is injected at runtime via env_file.
+ARG DATABASE_URL="postgresql://build_placeholder@db_placeholder:5432/db_placeholder"
 ENV DATABASE_URL=$DATABASE_URL
 
 ENV NEXT_TELEMETRY_DISABLED=1
@@ -71,7 +70,6 @@ RUN addgroup --system --gid 1001 nodejs \
  && adduser  --system --uid 1001 nextjs
 
 # Copy only what Next.js needs to serve the app.
-# This project does NOT use output:"standalone", so we copy the full build.
 COPY --from=builder --chown=nextjs:nodejs /app/public        ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next         ./.next
 COPY --from=builder --chown=nextjs:nodejs /app/node_modules  ./node_modules
@@ -84,4 +82,5 @@ EXPOSE 3003
 
 # Use dumb-init as PID 1 so signals are forwarded correctly
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
-CMD ["node", "node_modules/next/dist/bin/next", "start", "--port", "3003"]
+# Use $PORT so runtime overrides take effect
+CMD ["sh", "-c", "node node_modules/next/dist/bin/next start --port ${PORT:-3003}"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,87 @@
+# ============================================================
+# Stage 1: deps — install all dependencies (including native)
+# ============================================================
+FROM node:22-alpine AS deps
+
+# native modules (sharp, better-sqlite3) need build tools
+RUN apk add --no-cache libc6-compat python3 make g++
+
+WORKDIR /app
+
+COPY package.json package-lock.json* bun.lock* ./
+COPY prisma ./prisma/
+
+# Install with npm ci (uses package-lock.json when present)
+# If only bun.lock is present the next line falls back gracefully
+RUN npm install --frozen-lockfile 2>/dev/null || npm install
+
+# Generate Prisma client after deps are installed
+RUN npx prisma generate
+
+# ============================================================
+# Stage 2: builder — compile the Next.js app
+# ============================================================
+FROM node:22-alpine AS builder
+
+RUN apk add --no-cache libc6-compat python3 make g++
+
+WORKDIR /app
+
+# Copy installed node_modules and generated Prisma client
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/prisma ./prisma
+
+# Copy the rest of the source
+COPY . .
+
+# Build-time env vars that Next.js bakes into the bundle.
+# NEXT_PUBLIC_* values must be present at build time.
+# Override these as build args if you need different values per environment.
+ARG NEXT_PUBLIC_SENTRY_DSN=""
+ENV NEXT_PUBLIC_SENTRY_DSN=$NEXT_PUBLIC_SENTRY_DSN
+
+# DATABASE_URL is required only at runtime (server-side Prisma),
+# but next build may call getStaticProps/generateStaticParams that touch the DB.
+# Pass a dummy value here; real value is injected at runtime via env_file.
+ARG DATABASE_URL="postgresql://placeholder:placeholder@placeholder:5432/placeholder"
+ENV DATABASE_URL=$DATABASE_URL
+
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV NODE_ENV=production
+
+RUN npm run build
+
+# ============================================================
+# Stage 3: runner — lean production image
+# ============================================================
+FROM node:22-alpine AS runner
+
+RUN apk add --no-cache libc6-compat dumb-init
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+# Default port — overridden by PORT env var at runtime
+ENV PORT=3003
+ENV HOSTNAME="0.0.0.0"
+
+# Create a non-root user for security
+RUN addgroup --system --gid 1001 nodejs \
+ && adduser  --system --uid 1001 nextjs
+
+# Copy only what Next.js needs to serve the app.
+# This project does NOT use output:"standalone", so we copy the full build.
+COPY --from=builder --chown=nextjs:nodejs /app/public        ./public
+COPY --from=builder --chown=nextjs:nodejs /app/.next         ./.next
+COPY --from=builder --chown=nextjs:nodejs /app/node_modules  ./node_modules
+COPY --from=builder --chown=nextjs:nodejs /app/package.json  ./package.json
+COPY --from=builder --chown=nextjs:nodejs /app/prisma        ./prisma
+
+USER nextjs
+
+EXPOSE 3003
+
+# Use dumb-init as PID 1 so signals are forwarded correctly
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+CMD ["node", "node_modules/next/dist/bin/next", "start", "--port", "3003"]

--- a/pricing-template.ts
+++ b/pricing-template.ts
@@ -335,6 +335,7 @@ export const PLANS = PLANS_OPTION_A;
 // Usage: canUse("aiAssistant", userPlan)
 // ============================================================
 export function canUse(feature: keyof Plan["features"], planId: PlanId): boolean {
+  if (planId === "free") return FREE_PLAN.features[feature];
   const plan = PLANS.find((p) => p.id === planId);
   if (!plan) return false;
   return plan.features[feature];
@@ -343,8 +344,10 @@ export function canUse(feature: keyof Plan["features"], planId: PlanId): boolean
 // ============================================================
 // HELPER: get limit for a given plan
 // Returns null if unlimited, 0 if plan not found
+// Handles both paid tiers (PLANS) and the free tier (FREE_PLAN)
 // ============================================================
 export function getLimit(limit: keyof Plan["limits"], planId: PlanId): number | null {
+  if (planId === "free") return FREE_PLAN.limits[limit];
   const plan = PLANS.find((p) => p.id === planId);
   if (!plan) return 0;
   return plan.limits[limit];

--- a/pricing-template.ts
+++ b/pricing-template.ts
@@ -1,0 +1,391 @@
+// ============================================================
+// KingCRMHub Pricing Template — ready to wire up
+// Created: 2026-04-29
+// Status: TEMPLATE ONLY — not yet connected to Stripe or DB
+// ============================================================
+// To implement: wire PLANS into:
+//   1. /src/app/pricing/page.tsx (display)
+//   2. /src/lib/plans.ts (feature gating)
+//   3. Stripe products/prices (billing)
+//   4. Middleware or API route (enforcement)
+// ============================================================
+
+export type PlanId = "free" | "starter" | "growth" | "pro" | "agency";
+
+export type Plan = {
+  id: PlanId;
+  name: string;
+  price: number; // USD/month
+  annualPrice: number; // USD/month billed annually (20% off)
+  stripeMonthlyPriceId: string; // TODO: fill in after creating Stripe products
+  stripeAnnualPriceId: string;  // TODO: fill in after creating Stripe products
+  highlighted: boolean; // show as "most popular"
+  limits: {
+    leads: number | null;         // null = unlimited
+    smsPerMonth: number | null;   // null = unlimited
+    aiQueriesPerMonth: number | null; // null = unlimited
+    emailCampaignsPerMonth: number | null;
+    pipelines: number | null;
+    teamSeats: number | null;
+    automationWorkflows: number | null;
+  };
+  features: {
+    // Core CRM
+    contactManagement: boolean;
+    pipeline: boolean;
+    tasks: boolean;
+    notes: boolean;
+    // Communication
+    emailIntegration: boolean;
+    smsAutomation: boolean;
+    // AI
+    aiAssistant: boolean;
+    aiLeadScoring: boolean;      // AI scores each lead 1-10
+    aiEmailSuggestions: boolean; // AI drafts email replies
+    // Marketing
+    campaigns: boolean;
+    analytics: boolean;
+    // Advanced
+    customFields: boolean;
+    apiAccess: boolean;
+    whiteLabel: boolean;
+    dedicatedSupport: boolean;
+  };
+  badge?: string; // e.g. "Most Popular"
+  description: string;
+};
+
+// ============================================================
+// OPTION A — 4-Tier Classic (RECOMMENDED)
+// Best matches user's 9.99/9.99 requirement
+// Clean upgrade path matching ActiveCampaign/HubSpot structure
+// ============================================================
+export const PLANS_OPTION_A: Plan[] = [
+  {
+    id: "starter",
+    name: "Starter",
+    price: 19.99,
+    annualPrice: 15.99,
+    stripeMonthlyPriceId: "price_TODO_starter_monthly",
+    stripeAnnualPriceId: "price_TODO_starter_annual",
+    highlighted: false,
+    limits: {
+      leads: 10_000,
+      smsPerMonth: 500,
+      aiQueriesPerMonth: 50,
+      emailCampaignsPerMonth: 5,
+      pipelines: 1,
+      teamSeats: 1,
+      automationWorkflows: 5,
+    },
+    features: {
+      contactManagement: true,
+      pipeline: true,
+      tasks: true,
+      notes: true,
+      emailIntegration: true,
+      smsAutomation: true,       // limited to 500/mo
+      aiAssistant: true,         // limited to 50 queries/mo
+      aiLeadScoring: false,
+      aiEmailSuggestions: false,
+      campaigns: false,
+      analytics: true,           // basic only
+      customFields: false,
+      apiAccess: false,
+      whiteLabel: false,
+      dedicatedSupport: false,
+    },
+    description: "Perfect for solopreneurs managing their first pipeline.",
+  },
+  {
+    id: "growth",
+    name: "Growth",
+    price: 49.99,
+    annualPrice: 39.99,
+    stripeMonthlyPriceId: "price_TODO_growth_monthly",
+    stripeAnnualPriceId: "price_TODO_growth_annual",
+    highlighted: true,
+    badge: "Most Popular",
+    limits: {
+      leads: 50_000,
+      smsPerMonth: 2_500,
+      aiQueriesPerMonth: 300,
+      emailCampaignsPerMonth: 30,
+      pipelines: 5,
+      teamSeats: 3,
+      automationWorkflows: 25,
+    },
+    features: {
+      contactManagement: true,
+      pipeline: true,
+      tasks: true,
+      notes: true,
+      emailIntegration: true,
+      smsAutomation: true,
+      aiAssistant: true,
+      aiLeadScoring: true,
+      aiEmailSuggestions: true,
+      campaigns: true,
+      analytics: true,           // full analytics
+      customFields: true,
+      apiAccess: false,
+      whiteLabel: false,
+      dedicatedSupport: false,
+    },
+    description: "For growing small businesses ready to automate.",
+  },
+  {
+    id: "pro",
+    name: "Pro",
+    price: 99.00,
+    annualPrice: 79.00,
+    stripeMonthlyPriceId: "price_TODO_pro_monthly",
+    stripeAnnualPriceId: "price_TODO_pro_annual",
+    highlighted: false,
+    limits: {
+      leads: 100_000,
+      smsPerMonth: 10_000,
+      aiQueriesPerMonth: 1_500,
+      emailCampaignsPerMonth: null, // unlimited
+      pipelines: null,              // unlimited
+      teamSeats: 10,
+      automationWorkflows: null,    // unlimited
+    },
+    features: {
+      contactManagement: true,
+      pipeline: true,
+      tasks: true,
+      notes: true,
+      emailIntegration: true,
+      smsAutomation: true,
+      aiAssistant: true,
+      aiLeadScoring: true,
+      aiEmailSuggestions: true,
+      campaigns: true,
+      analytics: true,
+      customFields: true,
+      apiAccess: true,
+      whiteLabel: false,
+      dedicatedSupport: false,
+    },
+    description: "Scale to six figures with advanced AI and automation.",
+  },
+  {
+    id: "agency",
+    name: "Agency",
+    price: 249.00,
+    annualPrice: 199.00,
+    stripeMonthlyPriceId: "price_TODO_agency_monthly",
+    stripeAnnualPriceId: "price_TODO_agency_annual",
+    highlighted: false,
+    limits: {
+      leads: null,        // unlimited
+      smsPerMonth: null,  // unlimited
+      aiQueriesPerMonth: null,
+      emailCampaignsPerMonth: null,
+      pipelines: null,
+      teamSeats: null,
+      automationWorkflows: null,
+    },
+    features: {
+      contactManagement: true,
+      pipeline: true,
+      tasks: true,
+      notes: true,
+      emailIntegration: true,
+      smsAutomation: true,
+      aiAssistant: true,
+      aiLeadScoring: true,
+      aiEmailSuggestions: true,
+      campaigns: true,
+      analytics: true,
+      customFields: true,
+      apiAccess: true,
+      whiteLabel: true,
+      dedicatedSupport: true,
+    },
+    description: "Unlimited everything. Built for agencies running multiple clients.",
+  },
+];
+
+// ============================================================
+// OPTION B — 3-Tier Aggressive (Simpler / lower entry barrier)
+// Pros: easier to explain, fewer decision points
+// Cons: large jump from 9.99 to 49 — skips 100K tier
+// ============================================================
+export const PLANS_OPTION_B: Plan[] = [
+  {
+    id: "starter",
+    name: "Starter",
+    price: 19.99,
+    annualPrice: 15.99,
+    stripeMonthlyPriceId: "price_TODO_starter_monthly",
+    stripeAnnualPriceId: "price_TODO_starter_annual",
+    highlighted: false,
+    limits: {
+      leads: 10_000,
+      smsPerMonth: 250,
+      aiQueriesPerMonth: 30,
+      emailCampaignsPerMonth: 3,
+      pipelines: 1,
+      teamSeats: 1,
+      automationWorkflows: 3,
+    },
+    features: {
+      contactManagement: true,
+      pipeline: true,
+      tasks: true,
+      notes: true,
+      emailIntegration: true,
+      smsAutomation: true,
+      aiAssistant: true,
+      aiLeadScoring: false,
+      aiEmailSuggestions: false,
+      campaigns: false,
+      analytics: true,
+      customFields: false,
+      apiAccess: false,
+      whiteLabel: false,
+      dedicatedSupport: false,
+    },
+    description: "Get started fast with the essentials.",
+  },
+  {
+    id: "growth",
+    name: "Plus",
+    price: 49.99,
+    annualPrice: 39.99,
+    stripeMonthlyPriceId: "price_TODO_plus_monthly",
+    stripeAnnualPriceId: "price_TODO_plus_annual",
+    highlighted: true,
+    badge: "Best Value",
+    limits: {
+      leads: 50_000,
+      smsPerMonth: 5_000,
+      aiQueriesPerMonth: 500,
+      emailCampaignsPerMonth: null,
+      pipelines: null,
+      teamSeats: 5,
+      automationWorkflows: null,
+    },
+    features: {
+      contactManagement: true,
+      pipeline: true,
+      tasks: true,
+      notes: true,
+      emailIntegration: true,
+      smsAutomation: true,
+      aiAssistant: true,
+      aiLeadScoring: true,
+      aiEmailSuggestions: true,
+      campaigns: true,
+      analytics: true,
+      customFields: true,
+      apiAccess: false,
+      whiteLabel: false,
+      dedicatedSupport: false,
+    },
+    description: "Everything you need to grow a serious business.",
+  },
+  {
+    id: "agency",
+    name: "Agency",
+    price: 149.00,
+    annualPrice: 119.00,
+    stripeMonthlyPriceId: "price_TODO_agency_monthly",
+    stripeAnnualPriceId: "price_TODO_agency_annual",
+    highlighted: false,
+    limits: {
+      leads: null,
+      smsPerMonth: null,
+      aiQueriesPerMonth: null,
+      emailCampaignsPerMonth: null,
+      pipelines: null,
+      teamSeats: null,
+      automationWorkflows: null,
+    },
+    features: {
+      contactManagement: true,
+      pipeline: true,
+      tasks: true,
+      notes: true,
+      emailIntegration: true,
+      smsAutomation: true,
+      aiAssistant: true,
+      aiLeadScoring: true,
+      aiEmailSuggestions: true,
+      campaigns: true,
+      analytics: true,
+      customFields: true,
+      apiAccess: true,
+      whiteLabel: true,
+      dedicatedSupport: true,
+    },
+    description: "Unlimited power for agencies and high-volume operations.",
+  },
+];
+
+// ============================================================
+// ACTIVE PLAN SET — swap this to switch which option is live
+// ============================================================
+export const PLANS = PLANS_OPTION_A;
+
+// ============================================================
+// HELPER: check if a feature is allowed for a given plan
+// Usage: canUse("aiAssistant", userPlan)
+// ============================================================
+export function canUse(feature: keyof Plan["features"], planId: PlanId): boolean {
+  const plan = PLANS.find((p) => p.id === planId);
+  if (!plan) return false;
+  return plan.features[feature];
+}
+
+// ============================================================
+// HELPER: get limit for a given plan
+// Returns null if unlimited, 0 if plan not found
+// ============================================================
+export function getLimit(limit: keyof Plan["limits"], planId: PlanId): number | null {
+  const plan = PLANS.find((p) => p.id === planId);
+  if (!plan) return 0;
+  return plan.limits[limit];
+}
+
+// ============================================================
+// FREE PLAN (no payment needed — used before user subscribes)
+// ============================================================
+export const FREE_PLAN: Plan = {
+  id: "free",
+  name: "Free",
+  price: 0,
+  annualPrice: 0,
+  stripeMonthlyPriceId: "",
+  stripeAnnualPriceId: "",
+  highlighted: false,
+  limits: {
+    leads: 500,
+    smsPerMonth: 0,
+    aiQueriesPerMonth: 5,
+    emailCampaignsPerMonth: 0,
+    pipelines: 1,
+    teamSeats: 1,
+    automationWorkflows: 0,
+  },
+  features: {
+    contactManagement: true,
+    pipeline: true,
+    tasks: true,
+    notes: true,
+    emailIntegration: false,
+    smsAutomation: false,
+    aiAssistant: true,          // 5 queries only
+    aiLeadScoring: false,
+    aiEmailSuggestions: false,
+    campaigns: false,
+    analytics: false,
+    customFields: false,
+    apiAccess: false,
+    whiteLabel: false,
+    dedicatedSupport: false,
+  },
+  description: "Try KingCRM free — no credit card required.",
+};

--- a/prisma/migrations/20260426_add_onboarding_fields/migration.sql
+++ b/prisma/migrations/20260426_add_onboarding_fields/migration.sql
@@ -1,0 +1,7 @@
+-- Add onboarding tracking fields to Organization
+-- These track whether the setup wizard has been completed and at what step
+
+ALTER TABLE "Organization"
+  ADD COLUMN IF NOT EXISTS "onboardingCompleted"   BOOLEAN   NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS "onboardingCompletedAt" TIMESTAMP(3),
+  ADD COLUMN IF NOT EXISTS "onboardingStep"        INTEGER   NOT NULL DEFAULT 0;

--- a/src/app/api/billing/checkout/route.ts
+++ b/src/app/api/billing/checkout/route.ts
@@ -18,23 +18,32 @@ const PRICE_IDS: Record<string, Record<string, string>> = {
 }
 
 export async function POST(request: Request) {
+  const session = await getServerSession(buildNextAuthOptions())
+  if (!session?.user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  // Parse and validate request body — return 400 on malformed JSON or missing fields
+  let planId: string | undefined
+  let interval: 'monthly' | 'yearly' | undefined
   try {
-    const session = await getServerSession(buildNextAuthOptions())
-    if (!session?.user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-    }
+    const body = (await request.json()) as { planId?: unknown; interval?: unknown }
+    if (typeof body.planId === 'string') planId = body.planId
+    if (body.interval === 'monthly' || body.interval === 'yearly') interval = body.interval
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
 
-    const { planId, interval } = (await request.json()) as { planId: string; interval: 'monthly' | 'yearly' }
+  if (!planId || !interval) {
+    return NextResponse.json({ error: 'planId and interval are required' }, { status: 400 })
+  }
 
-    if (!planId || !interval) {
-      return NextResponse.json({ error: 'planId and interval are required' }, { status: 400 })
-    }
+  const priceId = PRICE_IDS[planId]?.[interval]
+  if (!priceId) {
+    return NextResponse.json({ error: 'Invalid plan' }, { status: 400 })
+  }
 
-    const priceId = PRICE_IDS[planId]?.[interval]
-    if (!priceId) {
-      return NextResponse.json({ error: 'Invalid plan' }, { status: 400 })
-    }
-
+  try {
     // TODO: Wire Stripe when ready:
     // const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, { apiVersion: '2024-06-20' })
     // const checkoutSession = await stripe.checkout.sessions.create({
@@ -54,7 +63,7 @@ export async function POST(request: Request) {
       interval,
     })
   } catch (error) {
-    console.error(error)
+    console.error('[billing/checkout] error:', error)
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }
 }

--- a/src/app/api/billing/checkout/route.ts
+++ b/src/app/api/billing/checkout/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { buildNextAuthOptions } from '@/lib/next-auth'
+
+const PRICE_IDS: Record<string, Record<string, string>> = {
+  starter: {
+    monthly: 'price_crm_starter_monthly_PLACEHOLDER',
+    yearly: 'price_crm_starter_yearly_PLACEHOLDER',
+  },
+  pro: {
+    monthly: 'price_crm_pro_monthly_PLACEHOLDER',
+    yearly: 'price_crm_pro_yearly_PLACEHOLDER',
+  },
+  enterprise: {
+    monthly: 'price_crm_enterprise_monthly_PLACEHOLDER',
+    yearly: 'price_crm_enterprise_yearly_PLACEHOLDER',
+  },
+}
+
+export async function POST(request: Request) {
+  try {
+    const session = await getServerSession(buildNextAuthOptions())
+    if (!session?.user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const { planId, interval } = (await request.json()) as { planId: string; interval: 'monthly' | 'yearly' }
+
+    if (!planId || !interval) {
+      return NextResponse.json({ error: 'planId and interval are required' }, { status: 400 })
+    }
+
+    const priceId = PRICE_IDS[planId]?.[interval]
+    if (!priceId) {
+      return NextResponse.json({ error: 'Invalid plan' }, { status: 400 })
+    }
+
+    // TODO: Wire Stripe when ready:
+    // const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, { apiVersion: '2024-06-20' })
+    // const checkoutSession = await stripe.checkout.sessions.create({
+    //   customer_email: session.user.email!,
+    //   line_items: [{ price: priceId, quantity: 1 }],
+    //   mode: 'subscription',
+    //   success_url: process.env.NEXTAUTH_URL + '/settings?upgraded=1',
+    //   cancel_url: process.env.NEXTAUTH_URL + '/pricing',
+    //   metadata: { userId: session.user.id },
+    // })
+    // return NextResponse.json({ url: checkoutSession.url })
+
+    return NextResponse.json({
+      url: null,
+      message: 'Payments are launching very soon. You will be notified by email when billing goes live.',
+      planId,
+      interval,
+    })
+  } catch (error) {
+    console.error(error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/onboarding/route.ts
+++ b/src/app/api/onboarding/route.ts
@@ -1,0 +1,148 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { buildNextAuthOptions } from '@/lib/next-auth'
+import { db } from '@/lib/db'
+import { z } from 'zod'
+
+const patchSchema = z.object({
+  step: z.number().int().min(0).max(10).optional(),
+  completed: z.boolean().optional(),
+})
+
+// GET /api/onboarding - return onboarding state for current org
+export async function GET(request: NextRequest) {
+  try {
+    const session = await getServerSession(buildNextAuthOptions(request))
+    if (!session?.user?.organizationId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    // Use raw query to gracefully handle the case where the migration hasn't run yet
+    // by defaulting to sensible values when columns don't exist
+    let onboardingCompleted = false
+    let onboardingCompletedAt: Date | null = null
+    let onboardingStep = 0
+
+    try {
+      const org = await db.organization.findUnique({
+        where: { id: session.user.organizationId },
+        select: {
+          onboardingCompleted: true,
+          onboardingCompletedAt: true,
+          onboardingStep: true,
+        },
+      })
+
+      if (org) {
+        onboardingCompleted = org.onboardingCompleted ?? false
+        onboardingCompletedAt = org.onboardingCompletedAt ?? null
+        onboardingStep = org.onboardingStep ?? 0
+      }
+    } catch {
+      // Columns may not exist yet if migration hasn't been applied — default to not completed
+      onboardingCompleted = false
+    }
+
+    // Get org stats separately
+    const counts = await db.organization.findUnique({
+      where: { id: session.user.organizationId },
+      select: {
+        _count: {
+          select: {
+            carriers: true,
+            leads: true,
+            teamMembers: true,
+          },
+        },
+      },
+    })
+
+    return NextResponse.json({
+      onboardingCompleted,
+      onboardingCompletedAt,
+      onboardingStep,
+      stats: {
+        carriers: counts?._count.carriers ?? 0,
+        leads: counts?._count.leads ?? 0,
+        teamMembers: counts?._count.teamMembers ?? 0,
+      },
+    })
+  } catch (error) {
+    console.error('GET /api/onboarding error:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+// PATCH /api/onboarding - update onboarding progress
+export async function PATCH(request: NextRequest) {
+  try {
+    const session = await getServerSession(buildNextAuthOptions(request))
+    if (!session?.user?.organizationId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const body = await request.json().catch(() => ({}))
+    const parsed = patchSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
+    }
+
+    const updateData: {
+      onboardingStep?: number
+      onboardingCompleted?: boolean
+      onboardingCompletedAt?: Date | null
+    } = {}
+
+    if (typeof parsed.data.step === 'number') {
+      updateData.onboardingStep = parsed.data.step
+    }
+
+    if (parsed.data.completed === true) {
+      updateData.onboardingCompleted = true
+      updateData.onboardingCompletedAt = new Date()
+    } else if (parsed.data.completed === false) {
+      updateData.onboardingCompleted = false
+      updateData.onboardingCompletedAt = null
+    }
+
+    let updated: { onboardingCompleted: boolean; onboardingStep: number; onboardingCompletedAt: Date | null } = {
+      onboardingCompleted: false,
+      onboardingStep: 0,
+      onboardingCompletedAt: null,
+    }
+
+    try {
+      updated = await db.organization.update({
+        where: { id: session.user.organizationId },
+        data: updateData,
+        select: {
+          onboardingCompleted: true,
+          onboardingStep: true,
+          onboardingCompletedAt: true,
+        },
+      })
+    } catch {
+      // Migration may not have run yet — gracefully ignore
+    }
+
+    // Log to audit trail
+    await db.auditLog.create({
+      data: {
+        organizationId: session.user.organizationId,
+        action: 'update',
+        entityType: 'onboarding',
+        entityId: session.user.organizationId,
+        actorId: session.user.id,
+        actorEmail: session.user.email,
+        description: parsed.data.completed
+          ? 'Completed onboarding setup wizard'
+          : `Advanced onboarding to step ${parsed.data.step ?? '?'}`,
+      },
+    })
+
+    return NextResponse.json({ success: true, ...updated })
+  } catch (error) {
+    console.error('PATCH /api/onboarding error:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/onboarding/route.ts
+++ b/src/app/api/onboarding/route.ts
@@ -43,7 +43,7 @@ export async function GET(request: NextRequest) {
       // Only swallow "column does not exist" errors from a pending migration.
       // Re-throw anything else so genuine DB failures surface correctly.
       const msg = err instanceof Error ? err.message : String(err)
-      if (!msg.includes('column') && !msg.includes('does not exist')) {
+      if (!msg.includes('column') || !msg.includes('does not exist')) {
         throw err
       }
       onboardingCompleted = false
@@ -140,7 +140,7 @@ export async function PATCH(request: NextRequest) {
       // Only swallow "column does not exist" from a pending migration.
       // All other DB errors (connection failures, constraint violations, etc.) should propagate.
       const msg = err instanceof Error ? err.message : String(err)
-      if (!msg.includes('column') && !msg.includes('does not exist')) {
+      if (!msg.includes('column') || !msg.includes('does not exist')) {
         throw err
       }
     }

--- a/src/app/api/onboarding/route.ts
+++ b/src/app/api/onboarding/route.ts
@@ -7,7 +7,10 @@ import { z } from 'zod'
 const patchSchema = z.object({
   step: z.number().int().min(0).max(10).optional(),
   completed: z.boolean().optional(),
-})
+}).refine(
+  (v) => v.step !== undefined || v.completed !== undefined,
+  { message: 'At least one of "step" or "completed" is required' }
+)
 
 // GET /api/onboarding - return onboarding state for current org
 export async function GET(request: NextRequest) {
@@ -17,8 +20,6 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
-    // Use raw query to gracefully handle the case where the migration hasn't run yet
-    // by defaulting to sensible values when columns don't exist
     let onboardingCompleted = false
     let onboardingCompletedAt: Date | null = null
     let onboardingStep = 0
@@ -38,12 +39,16 @@ export async function GET(request: NextRequest) {
         onboardingCompletedAt = org.onboardingCompletedAt ?? null
         onboardingStep = org.onboardingStep ?? 0
       }
-    } catch {
-      // Columns may not exist yet if migration hasn't been applied — default to not completed
+    } catch (err: unknown) {
+      // Only swallow "column does not exist" errors from a pending migration.
+      // Re-throw anything else so genuine DB failures surface correctly.
+      const msg = err instanceof Error ? err.message : String(err)
+      if (!msg.includes('column') && !msg.includes('does not exist')) {
+        throw err
+      }
       onboardingCompleted = false
     }
 
-    // Get org stats separately
     const counts = await db.organization.findUnique({
       where: { id: session.user.organizationId },
       select: {
@@ -81,10 +86,20 @@ export async function PATCH(request: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
-    const body = await request.json().catch(() => ({}))
+    // Parse body — return 400 on bad JSON or empty payload
+    let body: unknown
+    try {
+      body = await request.json()
+    } catch {
+      return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+    }
+
     const parsed = patchSchema.safeParse(body)
     if (!parsed.success) {
-      return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
+      return NextResponse.json(
+        { error: parsed.error.errors[0]?.message ?? 'Invalid request body' },
+        { status: 400 }
+      )
     }
 
     const updateData: {
@@ -121,11 +136,15 @@ export async function PATCH(request: NextRequest) {
           onboardingCompletedAt: true,
         },
       })
-    } catch {
-      // Migration may not have run yet — gracefully ignore
+    } catch (err: unknown) {
+      // Only swallow "column does not exist" from a pending migration.
+      // All other DB errors (connection failures, constraint violations, etc.) should propagate.
+      const msg = err instanceof Error ? err.message : String(err)
+      if (!msg.includes('column') && !msg.includes('does not exist')) {
+        throw err
+      }
     }
 
-    // Log to audit trail
     await db.auditLog.create({
       data: {
         organizationId: session.user.organizationId,

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -1,0 +1,5 @@
+import { CrmPricingPage } from '@/components/pricing/crm-pricing-page'
+
+export default function Pricing() {
+  return <CrmPricingPage />
+}

--- a/src/components/app/page.tsx
+++ b/src/components/app/page.tsx
@@ -1,0 +1,3595 @@
+"use client"
+
+import { useState, useEffect, useCallback } from "react"
+import { motion, AnimatePresence } from "framer-motion"
+import {
+  LayoutDashboard, Users, GitBranch, Brain, Share2, Settings,
+  Menu, X, Bell, Search, Plus, TrendingUp, TrendingDown,
+  Target, DollarSign, Activity, Zap, Calendar, Mail, Phone,
+  MessageSquare, ChevronRight, Star, Clock, CheckCircle2,
+  AlertCircle, BarChart3, PieChart, ArrowUpRight, Filter,
+  MoreHorizontal, Edit, Trash2, Eye, Sparkles, RefreshCw,
+  Send, FileText, ImageIcon, Video, Globe, Linkedin, Twitter,
+  Facebook, Instagram, Play, Pause, ExternalLink,
+  Moon, Sun, LogOut, User, Building2, Shield, Key, Webhook,
+  Database, Server, Cpu, HardDrive, Wifi, Check, XCircle,
+  Upload, Download, Layers, Tag, UserPlus, Bot, Wand2,
+  FileSpreadsheet, AlertTriangle, Info, FileUp, History,
+  ListFilter, SlidersHorizontal, Grid, List, ChevronDown,
+  SquareKanban, Circle, Link2
+} from "lucide-react"
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { Separator } from "@/components/ui/separator"
+import { Progress } from "@/components/ui/progress"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger, DialogFooter } from "@/components/ui/dialog"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
+import { Switch } from "@/components/ui/switch"
+import { Label } from "@/components/ui/label"
+import { Slider } from "@/components/ui/slider"
+import { type Lead, type PipelineItem, type PipelineStage, type Activity as ActivityType, type AIInsight } from "@/lib/store"
+import { DndContext, closestCenter, KeyboardSensor, PointerSensor, useDroppable, useSensor, useSensors, type DragEndEvent } from "@dnd-kit/core"
+import { SortableContext, sortableKeyboardCoordinates, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable"
+import { CSS } from "@dnd-kit/utilities"
+import { ChartContainer, ChartTooltip, ChartTooltipContent, type ChartConfig } from "@/components/ui/chart"
+import { AreaChart, Area, XAxis, YAxis, CartesianGrid, ResponsiveContainer, BarChart, Bar, PieChart as RechartsPieChart, Pie, Cell, LineChart, Line } from "recharts"
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
+import { AppShell } from "@/components/app/app-shell"
+import { WorkspaceOverlays } from "@/components/app/workspace-overlays"
+import { useWorkspaceOverlays } from "@/components/app/use-workspace-overlays"
+import { useWorkspaceSession } from "@/components/app/use-workspace-session"
+import { SettingsView } from "@/components/settings/settings-view"
+import { AiAssistantView } from "@/components/ai/ai-assistant-view"
+import { HelpCenterView } from "@/components/help/help-center-view"
+import { toast } from "@/hooks/use-toast"
+import { buildApiPath, readApiJsonOrText } from "@/lib/api-client"
+import { OnboardingWizard, IncompleteSetupBanner, useOnboarding } from "@/components/onboarding/onboarding-wizard"
+
+// ============================================
+// KING CRM HUB - ELITE DASHBOARD
+// Cream background with cobalt accents
+// Matching landing page aesthetic
+// ============================================
+
+// Mock Data - fixed ISO dates to avoid hydration mismatch
+const _base = "2026-03-11T22:00:00.000Z"
+const _yesterday = "2026-03-10T22:00:00.000Z"
+const mockLeads: Lead[] = [
+  { id: "1", firstName: "Sarah", lastName: "Johnson", email: "sarah@techcorp.com", phone: "(555) 123-4567", company: "TechCorp Inc", title: "CTO", source: "linkedin", status: "qualified", aiScore: 92, aiConfidence: 0.89, aiInsights: { intent: "high", budget: "confirmed" }, aiNextAction: "Schedule demo call", estimatedValue: 50000, lastContactedAt: _base, createdAt: _base, tags: [{ id: "1", name: "Hot Lead", color: "#2563EB" }] },
+  { id: "2", firstName: "Michael", lastName: "Chen", email: "mchen@startup.io", phone: "(555) 234-5678", company: "Startup.io", title: "Founder", source: "referral", status: "new", aiScore: 78, aiConfidence: 0.75, aiInsights: { intent: "medium" }, aiNextAction: "Send introductory email", estimatedValue: 25000, lastContactedAt: null, createdAt: _base, tags: [] },
+  { id: "3", firstName: "Emily", lastName: "Davis", email: "emily@enterprise.com", phone: "(555) 345-6789", company: "Enterprise Solutions", title: "VP of Sales", source: "website", status: "proposal", aiScore: 85, aiConfidence: 0.82, aiInsights: { intent: "high", timeline: "Q1" }, aiNextAction: "Follow up on proposal", estimatedValue: 75000, lastContactedAt: _yesterday, createdAt: _base, tags: [{ id: "2", name: "Enterprise", color: "#0F172A" }] },
+  { id: "4", firstName: "James", lastName: "Wilson", email: "jwilson@agency.co", phone: "(555) 456-7890", company: "Creative Agency", title: "Director", source: "google", status: "negotiation", aiScore: 88, aiConfidence: 0.91, aiInsights: { intent: "high", decisionMaker: true }, aiNextAction: "Send contract", estimatedValue: 120000, lastContactedAt: _base, createdAt: _base, tags: [] },
+  { id: "5", firstName: "Lisa", lastName: "Anderson", email: "lisa@retail.com", phone: "(555) 567-8901", company: "Retail Giants", title: "CEO", source: "referral", status: "new", aiScore: 65, aiConfidence: 0.68, aiInsights: {}, aiNextAction: "Research company needs", estimatedValue: 30000, lastContactedAt: null, createdAt: _base, tags: [] },
+]
+
+const _p1Close = "2026-04-10T22:00:00.000Z"
+const _p2Close = "2026-05-10T22:00:00.000Z"
+const _p3Close = "2026-03-25T22:00:00.000Z"
+const _p4Close = "2026-03-30T22:00:00.000Z"
+const _p5Close = "2026-03-22T22:00:00.000Z"
+const mockPipelineStages = [
+  { id: "new", name: "New", color: "#0F172A", order: 0, items: [
+    { id: "p1", title: "Michael Chen - Startup.io", value: 25000, probability: 20, stageId: "new", leadId: "2", lead: mockLeads[1], aiWinProbability: 0.35, expectedClose: _p1Close },
+    { id: "p2", title: "Lisa Anderson - Retail Giants", value: 30000, probability: 15, stageId: "new", leadId: "5", lead: mockLeads[4], aiWinProbability: 0.28, expectedClose: _p2Close },
+  ]},
+  { id: "contacted", name: "Contacted", color: "#6B7280", order: 1, items: [] },
+  { id: "qualified", name: "Qualified", color: "#2563EB", order: 2, items: [
+    { id: "p3", title: "Sarah Johnson - TechCorp", value: 50000, probability: 60, stageId: "qualified", leadId: "1", lead: mockLeads[0], aiWinProbability: 0.72, expectedClose: _p3Close },
+  ]},
+  { id: "proposal", name: "Proposal", color: "#0284C7", order: 3, items: [
+    { id: "p4", title: "Emily Davis - Enterprise", value: 75000, probability: 70, stageId: "proposal", leadId: "3", lead: mockLeads[2], aiWinProbability: 0.68, expectedClose: _p4Close },
+  ]},
+  { id: "negotiation", name: "Negotiation", color: "#64748B", order: 4, items: [
+    { id: "p5", title: "James Wilson - Agency", value: 120000, probability: 85, stageId: "negotiation", leadId: "4", lead: mockLeads[3], aiWinProbability: 0.89, expectedClose: _p5Close },
+  ]},
+  { id: "won", name: "Won", color: "#059669", order: 5, items: [] },
+]
+
+// Fixed ISO timestamps to avoid hydration mismatch (no Date.now() at module load)
+const _now = "2026-03-11T22:00:00.000Z"
+const mockActivities: ActivityType[] = [
+  { id: "1", type: "email", title: "Sent proposal to Sarah Johnson", description: "Follow-up email with pricing", metadata: { opened: true }, aiSummary: "Lead showed interest in premium plan", createdAt: _now, lead: mockLeads[0] },
+  { id: "2", type: "call", title: "Discovery call with James Wilson", description: "Discussed requirements and timeline", metadata: { duration: 45 }, aiSummary: "Decision maker engaged, ready for proposal", createdAt: "2026-03-11T21:00:00.000Z", lead: mockLeads[3] },
+  { id: "3", type: "ai_analysis", title: "AI scored new lead", description: "Michael Chen scored 78/100", metadata: { score: 78 }, aiSummary: "High potential - immediate follow-up recommended", createdAt: "2026-03-11T20:00:00.000Z", lead: mockLeads[1] },
+  { id: "4", type: "meeting", title: "Demo scheduled", description: "Product demo with Enterprise Solutions", metadata: {}, aiSummary: null, createdAt: "2026-03-10T22:00:00.000Z", lead: mockLeads[2] },
+]
+
+const mockInsights: AIInsight[] = [
+  { id: "1", type: "prediction", category: "pipeline", title: "Revenue Forecast", description: "Based on current pipeline velocity, you're projected to close $280K this quarter", data: { confidence: 0.82 }, confidence: 0.82, actionable: true, dismissed: false },
+  { id: "2", type: "recommendation", category: "leads", title: "Follow-up Alert", description: "3 leads haven't been contacted in 7+ days. Immediate outreach recommended.", data: { leads: ["2", "5"] }, confidence: 0.95, actionable: true, dismissed: false },
+  { id: "3", type: "trend", category: "performance", title: "Conversion Rate Up", description: "Your lead-to-opportunity conversion increased 12% this month", data: { change: 0.12 }, confidence: 0.88, actionable: false, dismissed: false },
+  { id: "4", type: "alert", category: "pipeline", title: "Deal at Risk", description: "James Wilson deal hasn't had activity in 5 days. Consider reaching out.", data: { dealId: "p5" }, confidence: 0.76, actionable: true, dismissed: false },
+]
+
+const chartData = [
+  { month: "Jan", leads: 45, won: 12, revenue: 85000 },
+  { month: "Feb", leads: 52, won: 18, revenue: 120000 },
+  { month: "Mar", leads: 48, won: 15, revenue: 95000 },
+  { month: "Apr", leads: 61, won: 22, revenue: 145000 },
+  { month: "May", leads: 55, won: 19, revenue: 130000 },
+  { month: "Jun", leads: 67, won: 28, revenue: 180000 },
+]
+
+const sourceData = [
+  { name: "LinkedIn", value: 35, color: "#2563EB" },
+  { name: "Referral", value: 28, color: "#0F172A" },
+  { name: "Website", value: 20, color: "#0EA5E9" },
+  { name: "Google", value: 12, color: "#14B8A6" },
+  { name: "Other", value: 5, color: "#64748B" },
+]
+
+const chartConfig: ChartConfig = {
+  leads: { label: "Leads", color: "#2563EB" },
+  won: { label: "Won", color: "#0F172A" },
+  revenue: { label: "Revenue", color: "#0EA5E9" },
+}
+
+type DashboardStats = {
+  totalLeads: number
+  newLeadsToday: number
+  pipelineValue: number
+  wonThisMonth: number
+  avgLeadScore: number
+  activitiesToday: number
+  sourceBreakdown: Array<{ name: string; value: number }>
+  leadTrend: Array<{ date: string; leads: number }>
+}
+
+type DashboardInsight = AIInsight & {
+  createdAt?: string
+}
+
+function normalizeLead(raw: Record<string, unknown>): Lead {
+  return {
+    id: String(raw.id),
+    firstName: typeof raw.firstName === "string" ? raw.firstName : null,
+    lastName: typeof raw.lastName === "string" ? raw.lastName : null,
+    email: typeof raw.email === "string" ? raw.email : null,
+    phone: typeof raw.phone === "string" ? raw.phone : null,
+    company: typeof raw.company === "string" ? raw.company : null,
+    title: typeof raw.title === "string" ? raw.title : null,
+    source: typeof raw.source === "string" ? raw.source : null,
+    status: typeof raw.status === "string" ? raw.status : "new",
+    aiScore: Number(raw.aiScore) || 0,
+    aiConfidence: raw.aiConfidence != null ? Number(raw.aiConfidence) : null,
+    aiInsights: raw.aiInsights && typeof raw.aiInsights === "object" && !Array.isArray(raw.aiInsights)
+      ? raw.aiInsights as Record<string, unknown>
+      : null,
+    aiNextAction: typeof raw.aiNextAction === "string" ? raw.aiNextAction : null,
+    estimatedValue: raw.estimatedValue != null ? Number(raw.estimatedValue) : null,
+    lastContactedAt: typeof raw.lastContactedAt === "string" ? raw.lastContactedAt : null,
+    createdAt: typeof raw.createdAt === "string" ? raw.createdAt : new Date().toISOString(),
+    tags: Array.isArray(raw.tags) ? raw.tags as { id: string; name: string; color: string }[] : [],
+  }
+}
+
+function normalizePipelineStages(rawStages: unknown): PipelineStage[] {
+  if (!Array.isArray(rawStages)) return []
+  return rawStages.map((stage, stageIndex) => {
+    const stageRecord = stage as Record<string, unknown>
+    return {
+      id: String(stageRecord.id),
+      name: typeof stageRecord.name === "string" ? stageRecord.name : `Stage ${stageIndex + 1}`,
+      color: typeof stageRecord.color === "string" ? stageRecord.color : "#2563EB",
+      order: typeof stageRecord.order === "number" ? stageRecord.order : stageIndex,
+      items: Array.isArray(stageRecord.items)
+        ? (stageRecord.items as Record<string, unknown>[]).map((item) => ({
+            id: String(item.id),
+            title: typeof item.title === "string" ? item.title : "Untitled deal",
+            value: item.value != null ? Number(item.value) : null,
+            probability: item.probability != null ? Number(item.probability) : null,
+            stageId: typeof item.stageId === "string" ? item.stageId : String(stageRecord.id),
+            leadId: typeof item.leadId === "string" ? item.leadId : null,
+            lead: item.lead && typeof item.lead === "object" ? normalizeLead(item.lead as Record<string, unknown>) : null,
+            aiWinProbability: item.aiWinProbability != null ? Number(item.aiWinProbability) : null,
+            expectedClose: typeof item.expectedClose === "string" ? item.expectedClose : null,
+          }))
+        : [],
+    }
+  })
+}
+
+function formatLeadTrend(data: DashboardStats["leadTrend"] | undefined) {
+  if (!Array.isArray(data) || data.length === 0) return chartData
+  return data.map((point) => ({
+    month: new Date(point.date).toLocaleDateString([], { month: "short", day: "numeric" }),
+    leads: point.leads,
+    won: 0,
+    revenue: 0,
+  }))
+}
+
+function formatSourceBreakdown(data: DashboardStats["sourceBreakdown"] | undefined) {
+  const palette = ["#2563EB", "#0F172A", "#0EA5E9", "#14B8A6", "#64748B", "#0284C7"]
+  if (!Array.isArray(data) || data.length === 0) return sourceData
+  return data.map((entry, index) => ({
+    name: entry.name,
+    value: entry.value,
+    color: palette[index % palette.length],
+  }))
+}
+
+function getActivityVisual(type: string) {
+  if (type === "email") return { icon: Mail, className: "bg-blue-100 text-blue-600" }
+  if (type === "call" || type === "sms") return { icon: Phone, className: "bg-emerald-100 text-emerald-600" }
+  if (type === "meeting") return { icon: Calendar, className: "bg-purple-100 text-purple-600" }
+  if (type.startsWith("ai")) return { icon: Brain, className: "bg-[#2563EB]/20 text-[#2563EB]" }
+  return { icon: Activity, className: "bg-gray-100 text-gray-600" }
+}
+
+// Utility Components
+function AnimatedNumber({ value, prefix = "", suffix = "" }: { value: number; prefix?: string; suffix?: string }) {
+  const [displayValue, setDisplayValue] = useState(0)
+  
+  useEffect(() => {
+    const duration = 500
+    const steps = 20
+    const stepValue = value / steps
+    let current = 0
+    let step = 0
+    const timer = setInterval(() => {
+      step++
+      current = Math.min(step * stepValue, value)
+      if (step >= steps) {
+        setDisplayValue(value)
+        clearInterval(timer)
+      } else {
+        setDisplayValue(Math.floor(current))
+      }
+    }, duration / steps)
+    return () => clearInterval(timer)
+  }, [value])
+  
+  return <span>{prefix}{displayValue.toLocaleString()}{suffix}</span>
+}
+
+function ScoreBadge({ score }: { score: number }) {
+  const color = score >= 80 ? "bg-gradient-to-r from-[#2563EB] to-[#14B8A6] text-black" : 
+                score >= 60 ? "bg-[#0EA5E9] text-white" : "bg-[#0F172A] text-white"
+  return (
+    <div className={cn("px-2 py-0.5 rounded text-xs font-semibold", color)}>
+      {score}
+    </div>
+  )
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const styles: Record<string, string> = {
+    new: "bg-[#0F172A] text-white",
+    contacted: "bg-gray-600 text-white",
+    qualified: "bg-[#2563EB] text-black",
+    proposal: "bg-blue-600 text-white",
+    negotiation: "bg-[#64748B] text-white",
+    won: "bg-emerald-600 text-white",
+    lost: "bg-red-600 text-white",
+  }
+  return (
+    <span className={cn("px-2 py-0.5 rounded text-xs font-medium capitalize", styles[status] || "bg-gray-500 text-white")}>
+      {status}
+    </span>
+  )
+}
+
+// Dashboard View
+function DashboardView() {
+  const [stats, setStats] = useState<DashboardStats | null>(null)
+  const [insights, setInsights] = useState<DashboardInsight[]>([])
+  const [activities, setActivities] = useState<ActivityType[]>([])
+  const [myDay, setMyDay] = useState<{
+    summary: string
+    leadsToCall: { id: string; name: string; company?: string | null; aiScore: number; reason: string }[]
+    meetings: { id: string; title: string; time: string; lead: { name: string } | null }[]
+  } | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+
+    ;(async () => {
+      try {
+        const [statsRes, insightsRes, activitiesRes, myDayRes] = await Promise.all([
+          fetch('/api/stats'),
+          fetch('/api/ai/insights?limit=4'),
+          fetch('/api/activities?limit=5'),
+          fetch('/api/ai/my-day?limit=5'),
+        ])
+
+        const [statsData, insightsData, activitiesData, myDayData] = await Promise.all([
+          statsRes.json(),
+          insightsRes.json(),
+          activitiesRes.json(),
+          myDayRes.json(),
+        ])
+
+        if (cancelled) return
+
+        if (!statsData.error) setStats(statsData)
+        if (!insightsData.error) setInsights(Array.isArray(insightsData.insights) ? insightsData.insights : [])
+        if (!activitiesData.error) {
+          setActivities(Array.isArray(activitiesData.activities) ? activitiesData.activities : [])
+        }
+        if (!myDayData.error) setMyDay(myDayData)
+      } catch {
+        // fall back to local defaults below
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const statCards = [
+    {
+      title: "Total Leads",
+      value: stats?.totalLeads ?? 0,
+      icon: Users,
+      color: "gold" as const,
+      detail: `${stats?.newLeadsToday ?? 0} new today`,
+    },
+    {
+      title: "Pipeline Value",
+      value: stats?.pipelineValue ?? 0,
+      icon: DollarSign,
+      color: "black" as const,
+      prefix: "$",
+      detail: `${stats?.activitiesToday ?? 0} activities today`,
+    },
+    {
+      title: "Avg Lead Score",
+      value: stats?.avgLeadScore ?? 0,
+      icon: Target,
+      color: "gold" as const,
+      detail: `${insights.length} live insights`,
+    },
+    {
+      title: "Won This Month",
+      value: stats?.wonThisMonth ?? 0,
+      icon: CheckCircle2,
+      color: "emerald" as const,
+      detail: loading ? "Loading…" : "Live from pipeline",
+    },
+  ]
+
+  const liveTrend = formatLeadTrend(stats?.leadTrend)
+  const liveSources = formatSourceBreakdown(stats?.sourceBreakdown)
+  const visibleInsights = insights.length > 0 ? insights.filter((i) => !i.dismissed).slice(0, 4) : mockInsights.slice(0, 4)
+  const visibleActivities = activities.length > 0 ? activities.slice(0, 5) : mockActivities.slice(0, 5)
+
+  if (loading) {
+    return (
+      <div className="p-6 space-y-6 bg-[#fcf8ec] min-h-screen">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+          {[1, 2, 3, 4].map((i) => (
+            <Card key={i} className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] shadow-sm">
+              <CardContent className="p-5 space-y-3">
+                <Skeleton className="h-4 w-24 bg-[rgba(31,42,54,0.06)]" />
+                <Skeleton className="h-8 w-16 bg-[rgba(31,42,54,0.06)]" />
+                <Skeleton className="h-3 w-32 bg-[rgba(31,42,54,0.06)]" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          <Card className="lg:col-span-2 bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] shadow-sm">
+            <CardContent className="p-6">
+              <Skeleton className="h-[280px] w-full bg-[rgba(31,42,54,0.04)]" />
+            </CardContent>
+          </Card>
+          <Card className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] shadow-sm">
+            <CardContent className="p-6">
+              <Skeleton className="h-[280px] w-full bg-[rgba(31,42,54,0.04)]" />
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="p-6 space-y-6 bg-[#fcf8ec] min-h-screen">
+      {/* Stats Grid */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+        {statCards.map((stat) => (
+          <Card key={stat.title} className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] shadow-sm hover:shadow-md transition-shadow card-hover">
+            <CardContent className="p-5">
+              <div className="flex items-start justify-between">
+                <div>
+                  <p className="text-sm text-gray-500">{stat.title}</p>
+                  <p className="text-2xl font-bold text-black mt-1">
+                    <AnimatedNumber value={stat.value} prefix={stat.prefix} />
+                  </p>
+                </div>
+                <div className={cn(
+                  "w-10 h-10 rounded-lg flex items-center justify-center",
+                  stat.color === "gold" && "bg-[#2563EB]/20",
+                  stat.color === "black" && "bg-[#0F172A]",
+                  stat.color === "emerald" && "bg-emerald-100",
+                )}>
+                  <stat.icon className={cn(
+                    "w-5 h-5",
+                    stat.color === "gold" && "text-[#2563EB]",
+                    stat.color === "black" && "text-white",
+                    stat.color === "emerald" && "text-emerald-600",
+                  )} />
+                </div>
+              </div>
+              <div className="flex items-center gap-2 mt-3 text-sm text-gray-500">
+                <TrendingUp className="w-4 h-4 text-emerald-500" />
+                <span>{stat.detail}</span>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+      
+      {/* Charts Row */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* Revenue Chart */}
+        <Card className="lg:col-span-2 bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] shadow-sm">
+          <CardHeader>
+            <CardTitle className="text-black">Revenue & Leads</CardTitle>
+            <CardDescription className="text-gray-500">Monthly performance overview</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ChartContainer config={chartConfig} className="h-[280px]">
+              <AreaChart data={liveTrend}>
+                <defs>
+                  <linearGradient id="colorLeads" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="5%" stopColor="#2563EB" stopOpacity={0.3}/>
+                    <stop offset="95%" stopColor="#2563EB" stopOpacity={0}/>
+                  </linearGradient>
+                  <linearGradient id="colorWon" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="5%" stopColor="#0F172A" stopOpacity={0.2}/>
+                    <stop offset="95%" stopColor="#0F172A" stopOpacity={0}/>
+                  </linearGradient>
+                </defs>
+                <CartesianGrid strokeDasharray="3 3" stroke="#D7DFEA" />
+                <XAxis dataKey="month" stroke="#6B7280" fontSize={12} />
+                <YAxis stroke="#6B7280" fontSize={12} />
+                <ChartTooltip content={<ChartTooltipContent />} />
+                <Area type="monotone" dataKey="leads" stroke="#2563EB" fillOpacity={1} fill="url(#colorLeads)" strokeWidth={2} />
+                <Area type="monotone" dataKey="won" stroke="#0F172A" fillOpacity={1} fill="url(#colorWon)" strokeWidth={2} />
+              </AreaChart>
+            </ChartContainer>
+          </CardContent>
+        </Card>
+        
+        {/* Lead Sources */}
+        <Card className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] shadow-sm">
+          <CardHeader>
+            <CardTitle className="text-black">Lead Sources</CardTitle>
+            <CardDescription className="text-gray-500">Distribution by channel</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="h-[200px]">
+              <ResponsiveContainer width="100%" height="100%">
+                <RechartsPieChart>
+                  <Pie
+                    data={liveSources}
+                    cx="50%"
+                    cy="50%"
+                    innerRadius={50}
+                    outerRadius={80}
+                    paddingAngle={4}
+                    dataKey="value"
+                  >
+                    {liveSources.map((entry, index) => (
+                      <Cell key={`cell-${index}`} fill={entry.color} />
+                    ))}
+                  </Pie>
+                </RechartsPieChart>
+              </ResponsiveContainer>
+            </div>
+            <div className="space-y-2 mt-4">
+              {liveSources.map((source) => (
+                <div key={source.name} className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <div className="w-3 h-3 rounded-full" style={{ backgroundColor: source.color }} />
+                    <span className="text-sm text-gray-600">{source.name}</span>
+                  </div>
+                  <span className="text-sm font-medium text-black">{source.value}</span>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+      
+      {/* AI Insights & Recent Activity */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* AI Insights */}
+        <Card className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] shadow-sm">
+          <CardHeader>
+            <div className="flex items-center gap-2">
+              <Sparkles className="w-5 h-5 text-[#2563EB]" />
+              <CardTitle className="text-black">AI Insights</CardTitle>
+            </div>
+            <CardDescription className="text-gray-500">Smart recommendations powered by AI</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {visibleInsights.map((insight) => (
+              <motion.div
+                key={insight.id}
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                className={cn(
+                  "p-3 rounded-lg border",
+                  insight.type === "prediction" && "bg-[#2563EB]/5 border-[#2563EB]/30",
+                  insight.type === "recommendation" && "bg-blue-50 border-blue-200",
+                  insight.type === "trend" && "bg-emerald-50 border-emerald-200",
+                  insight.type === "alert" && "bg-amber-50 border-amber-200",
+                )}
+              >
+                <div className="flex items-start justify-between">
+                  <div className="flex-1">
+                    <div className="flex items-center gap-2">
+                      <span className={cn(
+                        "text-xs font-medium uppercase",
+                        insight.type === "prediction" && "text-[#2563EB]",
+                        insight.type === "recommendation" && "text-blue-600",
+                        insight.type === "trend" && "text-emerald-600",
+                        insight.type === "alert" && "text-amber-600",
+                      )}>
+                        {insight.type}
+                      </span>
+                      {insight.confidence && (
+                        <Badge variant="outline" className="text-xs border-gray-300 text-gray-600">
+                          {Math.round(insight.confidence * 100)}% confidence
+                        </Badge>
+                      )}
+                    </div>
+                    <h4 className="text-sm font-medium text-black mt-1">{insight.title}</h4>
+                    <p className="text-xs text-gray-500 mt-0.5">{insight.description}</p>
+                  </div>
+                  {insight.actionable && (
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className="text-[#2563EB] hover:bg-[#2563EB]/10 h-7 px-2"
+                      onClick={() =>
+                        toast({
+                          title: insight.title,
+                          description: 'Open the relevant lead, pipeline, or task workflow from this insight card.',
+                        })
+                      }
+                    >
+                      <ArrowUpRight className="w-4 h-4" />
+                    </Button>
+                  )}
+                </div>
+              </motion.div>
+            ))}
+          </CardContent>
+        </Card>
+        
+        {/* Recent Activity */}
+        <Card className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] shadow-sm">
+          <CardHeader>
+            <div className="flex items-center gap-2">
+              <Activity className="w-5 h-5 text-[#2563EB]" />
+              <CardTitle className="text-black">Recent Activity</CardTitle>
+            </div>
+            <CardDescription className="text-gray-500">Latest actions and updates</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-4">
+              {visibleActivities.map((activity) => {
+                const visual = getActivityVisual(activity.type)
+                return (
+                <div key={activity.id} className="flex items-start gap-3">
+                  <div className={cn("w-8 h-8 rounded-lg flex items-center justify-center shrink-0", visual.className)}>
+                    <visual.icon className="w-4 h-4" />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm text-black truncate">{activity.title}</p>
+                    <p className="text-xs text-gray-500 truncate">{activity.description}</p>
+                    <p className="text-xs text-gray-400 mt-1" suppressHydrationWarning>
+                      {new Date(activity.createdAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                    </p>
+                  </div>
+                </div>
+              )})}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {myDay && (
+        <Card className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] shadow-sm">
+          <CardHeader>
+            <div className="flex items-center gap-2">
+              <Bot className="w-5 h-5 text-[#2563EB]" />
+              <CardTitle className="text-black">AI Daily Assistant</CardTitle>
+            </div>
+            <CardDescription className="text-gray-500">{myDay.summary}</CardDescription>
+          </CardHeader>
+          <CardContent className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            <div>
+              <h4 className="text-sm font-semibold text-black mb-3">Priority Leads to Call</h4>
+              <div className="space-y-2">
+                {myDay.leadsToCall.slice(0, 5).map((lead) => (
+                  <div key={lead.id} className="p-3 bg-[#EEF2F7] rounded-lg border border-[rgba(31,42,54,0.08)]">
+                    <p className="text-sm font-medium text-black">{lead.name}</p>
+                    <p className="text-xs text-gray-500">{lead.company || 'Unknown company'}</p>
+                    <div className="flex items-center justify-between mt-2">
+                      <ScoreBadge score={lead.aiScore} />
+                      <span className="text-xs text-gray-500">{lead.reason}</span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+            <div>
+              <h4 className="text-sm font-semibold text-black mb-3">Upcoming Meetings</h4>
+              <div className="space-y-2">
+                {myDay.meetings.length === 0 ? (
+                  <div className="p-3 bg-[#EEF2F7] rounded-lg border border-[rgba(31,42,54,0.08)] text-sm text-gray-500">
+                    No meetings queued yet.
+                  </div>
+                ) : myDay.meetings.slice(0, 5).map((meeting) => (
+                  <div key={meeting.id} className="p-3 bg-[#EEF2F7] rounded-lg border border-[rgba(31,42,54,0.08)]">
+                    <p className="text-sm font-medium text-black">{meeting.title}</p>
+                    <p className="text-xs text-gray-500">{meeting.lead?.name || 'Unassigned lead'}</p>
+                    <p className="text-xs text-gray-500 mt-1">{new Date(meeting.time).toLocaleString()}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  )
+}
+
+// Leads View with CSV Upload - fetches real data from API
+function LeadsView({ onAddLead, onUploadCSV, onScrape, refreshKey = 0 }: { onAddLead: () => void; onUploadCSV: () => void; onScrape: () => void; refreshKey?: number }) {
+  type CarrierPlaybook = {
+    recommendedCarrier: {
+      id: string | null
+      name: string
+      rationale: string
+      confidence: number
+    }
+    backupCarriers: Array<{
+      id: string | null
+      name: string
+      rationale: string
+    }>
+    suggestedPlanType: string
+    qualificationSummary: string[]
+    objectionHandling: string[]
+    followUpScripts: {
+      callOpening: string
+      sms: string
+      emailSubject: string
+      emailBody: string
+    }
+    nextActions: string[]
+    citations: Array<{
+      carrierId: string | null
+      carrierName: string
+      documentId: string
+      documentName: string
+      chunkIndex: number
+      snippet: string
+    }>
+  }
+
+  const [selectedLead, setSelectedLead] = useState<Lead | null>(null)
+  const [showEditLeadDialog, setShowEditLeadDialog] = useState(false)
+  const [showContactLeadDialog, setShowContactLeadDialog] = useState(false)
+  const [editLeadForm, setEditLeadForm] = useState({
+    firstName: '',
+    lastName: '',
+    email: '',
+    phone: '',
+    company: '',
+    title: '',
+    source: 'manual',
+    status: 'new',
+    estimatedValue: '',
+    aiNextAction: '',
+  })
+  const [contactMessage, setContactMessage] = useState('')
+  const [filterStatus, setFilterStatus] = useState<string>("all")
+  const [sortBy, setSortBy] = useState<string>("score")
+  const [leads, setLeads] = useState<Lead[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [assistantLoading, setAssistantLoading] = useState(false)
+  const [assistantSaving, setAssistantSaving] = useState(false)
+  const [assistantPlaybook, setAssistantPlaybook] = useState<CarrierPlaybook | null>(null)
+  const [assistantSource, setAssistantSource] = useState<'llm' | 'fallback' | null>(null)
+
+  useEffect(() => {
+    setLoading(true)
+    setError(null)
+    fetch("/api/leads?limit=200")
+      .then((r) => r.json())
+      .then((data) => {
+        if (data.error) throw new Error(data.error)
+        const list = (data.leads || []).map((l: Record<string, unknown>) => ({
+          id: l.id,
+          firstName: l.firstName ?? null,
+          lastName: l.lastName ?? null,
+          email: l.email ?? null,
+          phone: l.phone ?? null,
+          company: l.company ?? null,
+          title: l.title ?? null,
+          source: l.source ?? null,
+          status: (l.status as string) || "new",
+          aiScore: Number(l.aiScore) ?? 0,
+          aiConfidence: l.aiConfidence != null ? Number(l.aiConfidence) : null,
+          aiInsights: (l.aiInsights as Record<string, unknown>) ?? null,
+          aiNextAction: (l.aiNextAction as string) ?? null,
+          estimatedValue: l.estimatedValue != null ? Number(l.estimatedValue) : null,
+          lastContactedAt: l.lastContactedAt ? String(l.lastContactedAt) : null,
+          createdAt: l.createdAt ? String(l.createdAt) : new Date().toISOString(),
+          tags: Array.isArray(l.tags) ? l.tags as { id: string; name: string; color: string }[] : [],
+        }))
+        setLeads(list)
+      })
+      .catch((e) => setError(e.message || "Failed to load leads"))
+      .finally(() => setLoading(false))
+  }, [refreshKey])
+
+  const refreshLeads = async () => {
+    setLoading(true)
+    try {
+      const r = await fetch('/api/leads?limit=200')
+      const data = await r.json()
+      if (data.error) throw new Error(data.error)
+      const list = (data.leads || []).map((l: Record<string, unknown>) => ({
+        id: l.id,
+        firstName: l.firstName ?? null,
+        lastName: l.lastName ?? null,
+        email: l.email ?? null,
+        phone: l.phone ?? null,
+        company: l.company ?? null,
+        title: l.title ?? null,
+        source: l.source ?? null,
+        status: (l.status as string) || "new",
+        aiScore: Number(l.aiScore) ?? 0,
+        aiConfidence: l.aiConfidence != null ? Number(l.aiConfidence) : null,
+        aiInsights: (l.aiInsights as Record<string, unknown>) ?? null,
+        aiNextAction: (l.aiNextAction as string) ?? null,
+        estimatedValue: l.estimatedValue != null ? Number(l.estimatedValue) : null,
+        lastContactedAt: l.lastContactedAt ? String(l.lastContactedAt) : null,
+        createdAt: l.createdAt ? String(l.createdAt) : new Date().toISOString(),
+        tags: Array.isArray(l.tags) ? l.tags as { id: string; name: string; color: string }[] : [],
+      }))
+      setLeads(list)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to refresh leads')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const rescoreLead = async (leadId: string) => {
+    try {
+      const res = await fetch(`/api/ai/score?leadId=${leadId}`)
+      const data = await res.json()
+      if (data.error) throw new Error(data.error)
+      toast({ title: 'Lead rescored', description: `New AI score: ${data.aiScore}` })
+      await refreshLeads()
+    } catch (error) {
+      toast({
+        title: 'Rescore failed',
+        description: error instanceof Error ? error.message : 'Unknown error',
+        variant: 'destructive',
+      })
+    }
+  }
+
+  const markOutcome = async (leadId: string, status: 'won' | 'lost') => {
+    try {
+      const patchRes = await fetch(`/api/leads/${leadId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status }),
+      })
+      const patchData = await patchRes.json()
+      if (patchData.error) throw new Error(patchData.error)
+
+      await fetch('/api/ai/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          entityType: 'lead_outcome',
+          entityId: leadId,
+          rating: status === 'won' ? 1 : -1,
+          feedback: `Lead marked as ${status}`,
+        }),
+      })
+
+      toast({ title: 'Outcome saved', description: `Lead marked as ${status}.` })
+      await refreshLeads()
+    } catch (error) {
+      toast({
+        title: 'Update failed',
+        description: error instanceof Error ? error.message : 'Unknown error',
+        variant: 'destructive',
+      })
+    }
+  }
+
+  const generateCarrierPlaybook = async (leadId: string) => {
+    try {
+      setAssistantLoading(true)
+      const res = await fetch('/api/ai/carrier-playbook', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ leadId }),
+      })
+      const data = await res.json()
+      if (data.error) throw new Error(data.error)
+      setAssistantPlaybook(data.playbook || null)
+      setAssistantSource((data.source as 'llm' | 'fallback') || null)
+      toast({
+        title: 'AI playbook generated',
+        description: data.source === 'fallback'
+          ? 'Generated from rule-based fallback because LLM output was unavailable.'
+          : 'Carrier recommendation and scripts are ready.',
+      })
+    } catch (playbookError) {
+      toast({
+        title: 'Playbook generation failed',
+        description: playbookError instanceof Error ? playbookError.message : 'Unknown error',
+        variant: 'destructive',
+      })
+    } finally {
+      setAssistantLoading(false)
+    }
+  }
+
+  const savePlaybookToTimeline = async (leadId: string) => {
+    if (!assistantPlaybook) return
+    try {
+      setAssistantSaving(true)
+      const res = await fetch('/api/ai/carrier-playbook/save', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          leadId,
+          source: assistantSource || 'manual',
+          playbook: assistantPlaybook,
+        }),
+      })
+      const data = await res.json()
+      if (data.error) throw new Error(data.error)
+      toast({
+        title: 'Playbook saved',
+        description: 'AI playbook was saved to the lead timeline.',
+      })
+    } catch (saveError) {
+      toast({
+        title: 'Save failed',
+        description: saveError instanceof Error ? saveError.message : 'Unknown error',
+        variant: 'destructive',
+      })
+    } finally {
+      setAssistantSaving(false)
+    }
+  }
+
+  const filteredLeads = leads
+    .filter(lead => filterStatus === "all" || lead.status === filterStatus)
+    .sort((a, b) => {
+      if (sortBy === "score") return b.aiScore - a.aiScore
+      if (sortBy === "value") return (b.estimatedValue || 0) - (a.estimatedValue || 0)
+      if (sortBy === "date") return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+      return 0
+    })
+
+  const openEditLead = () => {
+    if (!selectedLead) return
+    setEditLeadForm({
+      firstName: selectedLead.firstName || '',
+      lastName: selectedLead.lastName || '',
+      email: selectedLead.email || '',
+      phone: selectedLead.phone || '',
+      company: selectedLead.company || '',
+      title: selectedLead.title || '',
+      source: selectedLead.source || 'manual',
+      status: selectedLead.status,
+      estimatedValue: selectedLead.estimatedValue != null ? String(selectedLead.estimatedValue) : '',
+      aiNextAction: selectedLead.aiNextAction || '',
+    })
+    setShowEditLeadDialog(true)
+  }
+
+  const saveLeadEdits = async () => {
+    if (!selectedLead) return
+    try {
+      const res = await fetch(`/api/leads/${selectedLead.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          ...editLeadForm,
+          estimatedValue: editLeadForm.estimatedValue ? Number(editLeadForm.estimatedValue) : null,
+        }),
+      })
+      const data = await res.json()
+      if (data.error) throw new Error(data.error)
+      toast({ title: 'Lead updated', description: 'Lead details saved successfully.' })
+      setShowEditLeadDialog(false)
+      await refreshLeads()
+    } catch (error) {
+      toast({
+        title: 'Lead update failed',
+        description: error instanceof Error ? error.message : 'Unknown error',
+        variant: 'destructive',
+      })
+    }
+  }
+
+  const openContactLead = () => {
+    if (!selectedLead) return
+    setContactMessage(selectedLead.aiNextAction ? `Hi ${selectedLead.firstName || ''}, ${selectedLead.aiNextAction}`.trim() : `Hi ${selectedLead.firstName || ''}, just following up from Insurafuze.`.trim())
+    setShowContactLeadDialog(true)
+  }
+
+  const sendLeadMessage = async () => {
+    if (!selectedLead) return
+    try {
+      const res = await fetch('/api/sms/send', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          leadId: selectedLead.id,
+          body: contactMessage,
+        }),
+      })
+      const data = await res.json()
+      if (data.error) throw new Error(data.error)
+      toast({ title: 'Lead contacted', description: data.message || 'Message recorded successfully.' })
+      setShowContactLeadDialog(false)
+      await refreshLeads()
+    } catch (error) {
+      toast({
+        title: 'Failed to contact lead',
+        description: error instanceof Error ? error.message : 'Unknown error',
+        variant: 'destructive',
+      })
+    }
+  }
+
+  return (
+    <div className="p-6 space-y-6 bg-[#fcf8ec] min-h-screen">
+      {/* Header with Add new lead + Import CSV on tab */}
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold text-black">Leads</h1>
+          <p className="text-gray-500">AI-powered lead management with smart scoring</p>
+        </div>
+        <div className="flex items-center gap-3">
+          <Button
+            variant="outline"
+            className="border-[#0F172A] text-[#0F172A] hover:bg-[#EEF2F7] gap-2"
+            onClick={onScrape}
+          >
+            <Globe className="w-4 h-4" />
+            Scrape Leads
+          </Button>
+          <Button 
+            variant="outline" 
+            className="border-[#2563EB] text-[#2563EB] hover:bg-[#2563EB]/10 gap-2"
+            onClick={onUploadCSV}
+          >
+            <Upload className="w-4 h-4" />
+            Import CSV
+          </Button>
+          <Button className="btn-gold gap-2" onClick={onAddLead}>
+            <Plus className="w-4 h-4" />
+            Add new lead
+          </Button>
+        </div>
+      </div>
+      
+      {/* Filters */}
+      <div className="flex items-center gap-4 flex-wrap">
+        <div className="flex items-center gap-2">
+          <Filter className="w-4 h-4 text-gray-400" />
+          <Select value={filterStatus} onValueChange={setFilterStatus}>
+            <SelectTrigger className="w-[140px] bg-[#fcfcfc] border-[rgba(31,42,54,0.08)]">
+              <SelectValue placeholder="Filter by status" />
+            </SelectTrigger>
+            <SelectContent className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)]">
+              <SelectItem value="all">All Status</SelectItem>
+              <SelectItem value="new">New</SelectItem>
+              <SelectItem value="qualified">Qualified</SelectItem>
+              <SelectItem value="proposal">Proposal</SelectItem>
+              <SelectItem value="negotiation">Negotiation</SelectItem>
+              <SelectItem value="won">Won</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <Select value={sortBy} onValueChange={setSortBy}>
+          <SelectTrigger className="w-[140px] bg-[#fcfcfc] border-[rgba(31,42,54,0.08)]">
+            <SelectValue placeholder="Sort by" />
+          </SelectTrigger>
+          <SelectContent className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)]">
+            <SelectItem value="score">AI Score</SelectItem>
+            <SelectItem value="value">Value</SelectItem>
+            <SelectItem value="date">Date Added</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      
+      {/* Leads Table */}
+      <Card className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] shadow-sm overflow-hidden">
+        {error && (
+          <div className="p-4 bg-amber-50 border-b border-amber-200 text-amber-800 text-sm">{error}</div>
+        )}
+        {loading ? (
+          <div className="p-8 text-center text-gray-500">Loading leads...</div>
+        ) : (
+          <div className="overflow-x-auto">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-[rgba(31,42,54,0.08)] bg-[#EEF2F7]">
+                <th className="text-left p-4 text-sm font-medium text-gray-600">Contact</th>
+                <th className="text-left p-4 text-sm font-medium text-gray-600">Company</th>
+                <th className="text-left p-4 text-sm font-medium text-gray-600">Source</th>
+                <th className="text-left p-4 text-sm font-medium text-gray-600">Status</th>
+                <th className="text-left p-4 text-sm font-medium text-gray-600">AI Score</th>
+                <th className="text-left p-4 text-sm font-medium text-gray-600">Value</th>
+                <th className="text-left p-4 text-sm font-medium text-gray-600">Next Action</th>
+                <th className="text-left p-4 text-sm font-medium text-gray-600"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {filteredLeads.length === 0 ? (
+                <tr><td colSpan={8} className="p-8 text-center text-gray-500">No leads yet. Add one or import a CSV.</td></tr>
+              ) : filteredLeads.map((lead) => (
+                <motion.tr
+                  key={lead.id}
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  className="border-b border-[rgba(31,42,54,0.08)] hover:bg-[#fcf8ec] transition-colors cursor-pointer"
+                  onClick={() => setSelectedLead(lead)}
+                >
+                  <td className="p-4">
+                    <div className="flex items-center gap-3">
+                      <Avatar className="w-9 h-9">
+                        <AvatarFallback className="bg-[#2563EB] text-black text-sm font-medium">
+                          {lead.firstName?.[0]}{lead.lastName?.[0]}
+                        </AvatarFallback>
+                      </Avatar>
+                      <div>
+                        <p className="text-sm font-medium text-black">{lead.firstName} {lead.lastName}</p>
+                        <p className="text-xs text-gray-500">{lead.email}</p>
+                      </div>
+                    </div>
+                  </td>
+                  <td className="p-4">
+                    <p className="text-sm text-black">{lead.company}</p>
+                    <p className="text-xs text-gray-500">{lead.title}</p>
+                  </td>
+                  <td className="p-4">
+                    <Badge variant="outline" className="capitalize border-[rgba(31,42,54,0.08)] text-gray-600">
+                      {lead.source}
+                    </Badge>
+                  </td>
+                  <td className="p-4">
+                    <StatusBadge status={lead.status} />
+                  </td>
+                  <td className="p-4">
+                    <div className="flex items-center gap-2">
+                      <ScoreBadge score={lead.aiScore} />
+                      {lead.aiConfidence && (
+                        <span className="text-xs text-gray-400">{Math.round(lead.aiConfidence * 100)}%</span>
+                      )}
+                    </div>
+                  </td>
+                  <td className="p-4">
+                    <span className="text-sm text-black font-medium">
+                      ${lead.estimatedValue?.toLocaleString() || '-'}
+                    </span>
+                  </td>
+                  <td className="p-4">
+                    <p className="text-sm text-gray-600 max-w-[200px] truncate">{lead.aiNextAction}</p>
+                  </td>
+                  <td className="p-4">
+                    <div className="flex items-center gap-1">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="text-[#2563EB] hover:bg-[#2563EB]/10"
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          void rescoreLead(lead.id)
+                        }}
+                      >
+                        Re-score
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="text-emerald-600 hover:bg-emerald-50"
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          void markOutcome(lead.id, 'won')
+                        }}
+                      >
+                        Won
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="text-red-600 hover:bg-red-50"
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          void markOutcome(lead.id, 'lost')
+                        }}
+                      >
+                        Lost
+                      </Button>
+                    </div>
+                  </td>
+                </motion.tr>
+              ))}
+            </tbody>
+          </table>
+          </div>
+        )}
+      </Card>
+      
+      {/* Lead Detail Modal */}
+      <Dialog
+        open={!!selectedLead}
+        onOpenChange={() => {
+          setSelectedLead(null)
+          setAssistantPlaybook(null)
+          setAssistantSource(null)
+          setAssistantLoading(false)
+          setAssistantSaving(false)
+        }}
+      >
+        <DialogContent className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] max-w-2xl">
+          {selectedLead && (
+            <>
+              <DialogHeader>
+                <DialogTitle className="text-xl text-black">Lead Details</DialogTitle>
+                <DialogDescription className="text-gray-500">
+                  AI-powered insights for {selectedLead.firstName} {selectedLead.lastName}
+                </DialogDescription>
+              </DialogHeader>
+              
+              <div className="grid grid-cols-2 gap-6 py-4">
+                <div className="space-y-4">
+                  <div>
+                    <Label className="text-gray-500 text-xs">Email</Label>
+                    <p className="text-black">{selectedLead.email}</p>
+                  </div>
+                  <div>
+                    <Label className="text-gray-500 text-xs">Phone</Label>
+                    <p className="text-black">{selectedLead.phone}</p>
+                  </div>
+                  <div>
+                    <Label className="text-gray-500 text-xs">Company</Label>
+                    <p className="text-black">{selectedLead.company}</p>
+                  </div>
+                  <div>
+                    <Label className="text-gray-500 text-xs">Title</Label>
+                    <p className="text-black">{selectedLead.title}</p>
+                  </div>
+                </div>
+                
+                <div className="space-y-4">
+                  <div>
+                    <Label className="text-gray-500 text-xs">AI Score</Label>
+                    <div className="flex items-center gap-2 mt-1">
+                      <ScoreBadge score={selectedLead.aiScore} />
+                      <Progress value={selectedLead.aiScore} className="flex-1 h-2" />
+                    </div>
+                  </div>
+                  <div>
+                    <Label className="text-gray-500 text-xs">Estimated Value</Label>
+                    <p className="text-black text-xl font-semibold">${selectedLead.estimatedValue?.toLocaleString()}</p>
+                  </div>
+                  <div>
+                    <Label className="text-gray-500 text-xs">AI Recommended Action</Label>
+                    <p className="text-[#2563EB]">{selectedLead.aiNextAction}</p>
+                  </div>
+                  <div>
+                    <Label className="text-gray-500 text-xs">Status</Label>
+                    <div className="mt-1">
+                      <StatusBadge status={selectedLead.status} />
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <Card className="bg-[#fcf8ec] border-[rgba(31,42,54,0.08)]">
+                <CardHeader className="pb-3">
+                  <CardTitle className="text-base flex items-center gap-2 text-black">
+                    <Bot className="w-4 h-4 text-[#2563EB]" />
+                    AI Carrier Assistant
+                  </CardTitle>
+                  <CardDescription>
+                    Recommends carrier + plan strategy and generates follow-up scripts from lead context and your carrier library.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <div className="flex items-center gap-2">
+                    <Button
+                      className="btn-gold gap-2"
+                      onClick={() => void generateCarrierPlaybook(selectedLead.id)}
+                      disabled={assistantLoading}
+                    >
+                      {assistantLoading ? (
+                        <>
+                          <RefreshCw className="w-4 h-4 animate-spin" />
+                          Generating...
+                        </>
+                      ) : (
+                        <>
+                          <Sparkles className="w-4 h-4" />
+                          Generate pitch playbook
+                        </>
+                      )}
+                    </Button>
+                    {assistantSource && (
+                      <Badge variant="outline" className="border-[rgba(31,42,54,0.08)] text-gray-600 capitalize">
+                        Source: {assistantSource}
+                      </Badge>
+                    )}
+                    <Button
+                      variant="outline"
+                      className="border-[rgba(31,42,54,0.08)] text-gray-700 hover:bg-[#EEF2F7]"
+                      disabled={!assistantPlaybook || assistantSaving}
+                      onClick={() => void savePlaybookToTimeline(selectedLead.id)}
+                    >
+                      {assistantSaving ? 'Saving...' : 'Save to timeline'}
+                    </Button>
+                  </div>
+
+                  {assistantPlaybook && (
+                    <div className="space-y-4">
+                      <div className="rounded-lg border border-[rgba(31,42,54,0.08)] bg-white p-4">
+                        <p className="text-xs text-gray-500">Recommended Carrier</p>
+                        <p className="text-sm font-semibold text-black mt-1">
+                          {assistantPlaybook.recommendedCarrier.name}
+                          <span className="text-xs text-gray-500 ml-2">
+                            ({Math.round((assistantPlaybook.recommendedCarrier.confidence || 0) * 100)}% confidence)
+                          </span>
+                        </p>
+                        <p className="text-sm text-gray-600 mt-2">{assistantPlaybook.recommendedCarrier.rationale}</p>
+                        <p className="text-sm text-[#2563EB] mt-2">
+                          Plan suggestion: {assistantPlaybook.suggestedPlanType}
+                        </p>
+                      </div>
+
+                      {assistantPlaybook.backupCarriers?.length > 0 && (
+                        <div>
+                          <p className="text-xs text-gray-500 mb-2">Backup Carriers</p>
+                          <div className="space-y-2">
+                            {assistantPlaybook.backupCarriers.map((carrier, idx) => (
+                              <div key={`${carrier.name}-${idx}`} className="rounded-lg border border-[rgba(31,42,54,0.08)] bg-white p-3">
+                                <p className="text-sm font-medium text-black">{carrier.name}</p>
+                                <p className="text-xs text-gray-600 mt-1">{carrier.rationale}</p>
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+                      )}
+
+                      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                        <div className="rounded-lg border border-[rgba(31,42,54,0.08)] bg-white p-3">
+                          <p className="text-xs text-gray-500 mb-2">Qualification Summary</p>
+                          <ul className="text-sm text-gray-700 space-y-1">
+                            {assistantPlaybook.qualificationSummary.map((item, idx) => (
+                              <li key={`qual-${idx}`}>• {item}</li>
+                            ))}
+                          </ul>
+                        </div>
+                        <div className="rounded-lg border border-[rgba(31,42,54,0.08)] bg-white p-3">
+                          <p className="text-xs text-gray-500 mb-2">Objection Handling</p>
+                          <ul className="text-sm text-gray-700 space-y-1">
+                            {assistantPlaybook.objectionHandling.map((item, idx) => (
+                              <li key={`obj-${idx}`}>• {item}</li>
+                            ))}
+                          </ul>
+                        </div>
+                      </div>
+
+                      <div className="rounded-lg border border-[rgba(31,42,54,0.08)] bg-white p-3 space-y-2">
+                        <p className="text-xs text-gray-500">Follow-up Scripts</p>
+                        <p className="text-sm text-gray-700"><span className="font-medium text-black">Call opening:</span> {assistantPlaybook.followUpScripts.callOpening}</p>
+                        <p className="text-sm text-gray-700"><span className="font-medium text-black">SMS:</span> {assistantPlaybook.followUpScripts.sms}</p>
+                        <p className="text-sm text-gray-700"><span className="font-medium text-black">Email subject:</span> {assistantPlaybook.followUpScripts.emailSubject}</p>
+                        <p className="text-sm text-gray-700 whitespace-pre-wrap"><span className="font-medium text-black">Email body:</span> {assistantPlaybook.followUpScripts.emailBody}</p>
+                      </div>
+
+                      {assistantPlaybook.citations?.length > 0 && (
+                        <div className="rounded-lg border border-[rgba(31,42,54,0.08)] bg-white p-3 space-y-2">
+                          <p className="text-xs text-gray-500">Grounding Citations</p>
+                          {assistantPlaybook.citations.slice(0, 4).map((c, idx) => (
+                            <div key={`${c.documentId}-${c.chunkIndex}-${idx}`} className="rounded border border-[#E6EDF7] bg-[#fcf8ec] p-2">
+                              <p className="text-xs font-medium text-black">
+                                {c.carrierName} - {c.documentName} (chunk {c.chunkIndex})
+                              </p>
+                              <p className="text-xs text-gray-600 mt-1">{c.snippet}</p>
+                            </div>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+              
+              <div className="flex justify-end gap-3">
+                <Button
+                  variant="outline"
+                  className="border-[rgba(31,42,54,0.08)] text-black hover:bg-[#EEF2F7]"
+                  onClick={openEditLead}
+                >
+                  <Edit className="w-4 h-4 mr-2" />
+                  Edit
+                </Button>
+                <Button
+                  variant="outline"
+                  className="border-[#5E6AD2] text-[#5E6AD2] hover:bg-[#5E6AD2]/10 gap-2"
+                  onClick={() => {
+                    setSelectedLead(null)
+                    if (typeof window !== "undefined") {
+                      window.dispatchEvent(new CustomEvent("create-linear-issue", {
+                        detail: {
+                          title: `Follow up: ${selectedLead.firstName} ${selectedLead.lastName} - ${selectedLead.company ?? ""}`.trim(),
+                          description: [
+                            `**Lead:** ${selectedLead.firstName} ${selectedLead.lastName}`,
+                            selectedLead.email ? `**Email:** ${selectedLead.email}` : null,
+                            selectedLead.company ? `**Company:** ${selectedLead.company}` : null,
+                            selectedLead.title ? `**Title:** ${selectedLead.title}` : null,
+                            selectedLead.aiNextAction ? `\n**AI Recommended Action:** ${selectedLead.aiNextAction}` : null,
+                            selectedLead.estimatedValue ? `**Est. Value:** $${selectedLead.estimatedValue.toLocaleString()}` : null,
+                          ].filter(Boolean).join("\n"),
+                        },
+                      }))
+                    }
+                  }}
+                >
+                  <SquareKanban className="w-4 h-4" />
+                  Create Linear Issue
+                </Button>
+                <Button className="btn-gold" onClick={openContactLead}>
+                  <Send className="w-4 h-4 mr-2" />
+                  Contact
+                </Button>
+              </div>
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={showEditLeadDialog} onOpenChange={setShowEditLeadDialog}>
+        <DialogContent className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] max-w-2xl">
+          <DialogHeader>
+            <DialogTitle className="text-black">Edit Lead</DialogTitle>
+            <DialogDescription>Update the lead’s CRM profile and workflow status.</DialogDescription>
+          </DialogHeader>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <Label className="text-gray-600">First name</Label>
+              <Input className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" value={editLeadForm.firstName} onChange={(e) => setEditLeadForm((prev) => ({ ...prev, firstName: e.target.value }))} />
+            </div>
+            <div>
+              <Label className="text-gray-600">Last name</Label>
+              <Input className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" value={editLeadForm.lastName} onChange={(e) => setEditLeadForm((prev) => ({ ...prev, lastName: e.target.value }))} />
+            </div>
+            <div>
+              <Label className="text-gray-600">Email</Label>
+              <Input className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" type="email" value={editLeadForm.email} onChange={(e) => setEditLeadForm((prev) => ({ ...prev, email: e.target.value }))} />
+            </div>
+            <div>
+              <Label className="text-gray-600">Phone</Label>
+              <Input className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" value={editLeadForm.phone} onChange={(e) => setEditLeadForm((prev) => ({ ...prev, phone: e.target.value }))} />
+            </div>
+            <div>
+              <Label className="text-gray-600">Company</Label>
+              <Input className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" value={editLeadForm.company} onChange={(e) => setEditLeadForm((prev) => ({ ...prev, company: e.target.value }))} />
+            </div>
+            <div>
+              <Label className="text-gray-600">Title</Label>
+              <Input className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" value={editLeadForm.title} onChange={(e) => setEditLeadForm((prev) => ({ ...prev, title: e.target.value }))} />
+            </div>
+            <div>
+              <Label className="text-gray-600">Source</Label>
+              <Input className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" value={editLeadForm.source} onChange={(e) => setEditLeadForm((prev) => ({ ...prev, source: e.target.value }))} />
+            </div>
+            <div>
+              <Label className="text-gray-600">Status</Label>
+              <Select value={editLeadForm.status} onValueChange={(value) => setEditLeadForm((prev) => ({ ...prev, status: value }))}>
+                <SelectTrigger className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]"><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="new">New</SelectItem>
+                  <SelectItem value="contacted">Contacted</SelectItem>
+                  <SelectItem value="qualified">Qualified</SelectItem>
+                  <SelectItem value="proposal">Proposal</SelectItem>
+                  <SelectItem value="negotiation">Negotiation</SelectItem>
+                  <SelectItem value="won">Won</SelectItem>
+                  <SelectItem value="lost">Lost</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <Label className="text-gray-600">Estimated value</Label>
+              <Input className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" type="number" value={editLeadForm.estimatedValue} onChange={(e) => setEditLeadForm((prev) => ({ ...prev, estimatedValue: e.target.value }))} />
+            </div>
+            <div className="md:col-span-2">
+              <Label className="text-gray-600">AI next action</Label>
+              <Textarea className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" value={editLeadForm.aiNextAction} onChange={(e) => setEditLeadForm((prev) => ({ ...prev, aiNextAction: e.target.value }))} />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" className="border-[rgba(31,42,54,0.08)]" onClick={() => setShowEditLeadDialog(false)}>Cancel</Button>
+            <Button className="btn-gold" onClick={() => void saveLeadEdits()}>Save lead</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={showContactLeadDialog} onOpenChange={setShowContactLeadDialog}>
+        <DialogContent className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)]">
+          <DialogHeader>
+            <DialogTitle className="text-black">Contact Lead</DialogTitle>
+            <DialogDescription>Send or record an SMS follow-up for this lead.</DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3">
+            <div>
+              <Label className="text-gray-600">To</Label>
+              <Input className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" value={selectedLead?.phone || ''} readOnly />
+            </div>
+            <div>
+              <Label className="text-gray-600">Message</Label>
+              <Textarea className="mt-1 min-h-28 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" value={contactMessage} onChange={(e) => setContactMessage(e.target.value)} />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" className="border-[rgba(31,42,54,0.08)]" onClick={() => setShowContactLeadDialog(false)}>Cancel</Button>
+            <Button className="btn-gold" onClick={() => void sendLeadMessage()}>Send message</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}
+
+// Pipeline View (Kanban)
+function SortableItem({ item }: { item: PipelineItem }) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: item.id })
+  
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  }
+  
+  return (
+    <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
+      <Card className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] hover:border-[#2563EB] cursor-grab active:cursor-grabbing mb-2 shadow-sm">
+        <CardContent className="p-3">
+          <div className="flex items-start justify-between mb-2">
+            <h4 className="text-sm font-medium text-black truncate flex-1">{item.title}</h4>
+          </div>
+          
+          {item.value && (
+            <p className="text-lg font-semibold text-black mb-2">${item.value.toLocaleString()}</p>
+          )}
+          
+          <div className="flex items-center justify-between">
+            {item.aiWinProbability && (
+              <Badge variant="outline" className="text-xs border-[#2563EB]/50 text-[#2563EB]">
+                {Math.round(item.aiWinProbability * 100)}% win
+              </Badge>
+            )}
+            {item.lead && (
+              <Avatar className="w-6 h-6">
+                <AvatarFallback className="bg-[#2563EB] text-black text-xs">
+                  {item.lead.firstName?.[0]}{item.lead.lastName?.[0]}
+                </AvatarFallback>
+              </Avatar>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+function PipelineStageColumn({
+  stage,
+  children,
+}: {
+  stage: PipelineStage
+  children: React.ReactNode
+}) {
+  const { setNodeRef, isOver } = useDroppable({ id: stage.id })
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={cn(
+        "shrink-0 w-[300px] bg-white rounded-lg border shadow-sm transition-colors",
+        isOver ? "border-[#2563EB] bg-[#EFF6FF]" : "border-[rgba(31,42,54,0.08)]"
+      )}
+    >
+      {children}
+    </div>
+  )
+}
+
+function PipelineView() {
+  const [stages, setStages] = useState<PipelineStage[]>([])
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  )
+
+  const loadPipeline = useCallback(async () => {
+    setLoading(true)
+    try {
+      const res = await fetch("/api/pipeline")
+      const data = await res.json()
+      if (data.error) throw new Error(data.error)
+      setStages(normalizePipelineStages(data.pipeline?.stages))
+    } catch (error) {
+      toast({
+        title: "Failed to load pipeline",
+        description: error instanceof Error ? error.message : "Unknown error",
+        variant: "destructive",
+      })
+      setStages(normalizePipelineStages(mockPipelineStages))
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void loadPipeline()
+  }, [loadPipeline])
+
+  const onDragEnd = useCallback(async (event: DragEndEvent) => {
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+
+    const activeId = String(active.id)
+    const overId = String(over.id)
+    const sourceStage = stages.find((stage) => stage.items.some((item) => item.id === activeId))
+    if (!sourceStage) return
+
+    const targetStage = stages.find((stage) => stage.id === overId || stage.items.some((item) => item.id === overId))
+    if (!targetStage) return
+
+    const movingItem = sourceStage.items.find((item) => item.id === activeId)
+    if (!movingItem) return
+
+    setStages((current) => {
+      const next = current.map((stage) => ({
+        ...stage,
+        items: stage.items.filter((item) => item.id !== activeId),
+      }))
+
+      const targetIndex = next.findIndex((stage) => stage.id === targetStage.id)
+      if (targetIndex !== -1) {
+        next[targetIndex] = {
+          ...next[targetIndex],
+          items: [...next[targetIndex].items, { ...movingItem, stageId: targetStage.id }],
+        }
+      }
+
+      return next
+    })
+
+    try {
+      setSaving(true)
+      const res = await fetch("/api/pipeline", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          itemId: activeId,
+          stageId: targetStage.id,
+          position: targetStage.items.length,
+        }),
+      })
+      const data = await res.json()
+      if (data.error) throw new Error(data.error)
+    } catch (error) {
+      toast({
+        title: "Pipeline move failed",
+        description: error instanceof Error ? error.message : "Unknown error",
+        variant: "destructive",
+      })
+      await loadPipeline()
+    } finally {
+      setSaving(false)
+    }
+  }, [loadPipeline, stages])
+  
+  const totalValue = stages.reduce((sum, stage) => 
+    sum + stage.items.reduce((s, item) => s + (item.value || 0), 0), 0
+  )
+  
+  return (
+    <div className="p-6 space-y-6 bg-[#fcf8ec] min-h-screen">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold text-black">Pipeline</h1>
+          <p className="text-gray-500">Drag and drop deals through your sales stages</p>
+        </div>
+        <div className="flex items-center gap-4">
+          <Card className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] px-4 py-2 shadow-sm">
+            <div className="flex items-center gap-2">
+              <DollarSign className="w-4 h-4 text-[#2563EB]" />
+              <span className="text-lg font-semibold text-black">${totalValue.toLocaleString()}</span>
+              <span className="text-sm text-gray-500">{saving ? "saving…" : "live total"}</span>
+            </div>
+          </Card>
+          <Button className="btn-gold gap-2" onClick={() => window.dispatchEvent(new CustomEvent("open-add-lead"))}>
+            <Plus className="w-4 h-4" />
+            Add Deal
+          </Button>
+        </div>
+      </div>
+      
+      {loading ? (
+        <div className="flex items-center justify-center py-16 text-gray-500">
+          <RefreshCw className="w-5 h-5 animate-spin mr-2" />
+          Loading pipeline…
+        </div>
+      ) : (
+        <>
+          {/* Kanban Board */}
+          <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={(event) => { void onDragEnd(event) }}>
+            <div className="flex gap-4 overflow-x-auto pb-4">
+              {stages.map((stage) => (
+                <PipelineStageColumn key={stage.id} stage={stage}>
+                  {/* Column Header */}
+                  <div
+                    className="p-3 border-b border-[rgba(31,42,54,0.08)] flex items-center justify-between"
+                    style={{ borderTopLeftRadius: 8, borderTopRightRadius: 8, borderTop: `3px solid ${stage.color}` }}
+                  >
+                    <div className="flex items-center gap-2">
+                      <h3 className="text-sm font-medium text-black">{stage.name}</h3>
+                      <Badge variant="secondary" className="bg-[#EEF2F7] text-gray-600">
+                        {stage.items.length}
+                      </Badge>
+                    </div>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-6 w-6 text-gray-400 hover:text-[#2563EB]"
+                      onClick={() => window.dispatchEvent(new CustomEvent("open-add-lead"))}
+                    >
+                      <Plus className="w-3 h-3" />
+                    </Button>
+                  </div>
+                  
+                  {/* Column Content */}
+                  <ScrollArea className="h-[calc(100vh-320px)]">
+                    <div className="p-2">
+                      <SortableContext items={stage.items.map((i) => i.id)} strategy={verticalListSortingStrategy}>
+                        {stage.items.map((item) => (
+                          <SortableItem key={item.id} item={item} />
+                        ))}
+                      </SortableContext>
+                      
+                      {stage.items.length === 0 && (
+                        <div className="text-center py-8 text-gray-400 text-sm">
+                          Drop a deal here
+                        </div>
+                      )}
+                    </div>
+                  </ScrollArea>
+                </PipelineStageColumn>
+              ))}
+            </div>
+          </DndContext>
+        </>
+      )}
+    </div>
+  )
+}
+
+// Upload record from API
+type UploadRecord = {
+  id: string
+  fileName: string
+  fileSize: number
+  totalRows: number
+  successfulRows: number
+  duplicateRows: number
+  failedRows: number
+  status: string
+  createdAt: string
+  aiAutoScored: boolean
+}
+
+// Uploads History View
+function UploadsView({ onUploadCSV, refreshKey = 0 }: { onUploadCSV: () => void; refreshKey?: number }) {
+  const [uploads, setUploads] = useState<UploadRecord[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      try {
+        const res = await fetch(buildApiPath('/api/upload?limit=100'))
+        const { data, text } = await readApiJsonOrText(res)
+        if (cancelled) return
+        if (!data) {
+          throw new Error(`Upload API returned non-JSON (${res.status}). ${text?.slice(0, 120) || ''}`.trim())
+        }
+        if (data.error) {
+          setError(data.error)
+          setUploads([])
+          return
+        }
+        const list = (data.uploads || []).map((u: {
+          id: string
+          fileName: string
+          fileSize: number
+          totalRows: number
+          successfulRows: number
+          duplicateRows: number
+          failedRows: number
+          status: string
+          createdAt: string
+          aiAutoScored: boolean
+        }) => ({
+          id: u.id,
+          fileName: u.fileName,
+          fileSize: u.fileSize,
+          totalRows: u.totalRows,
+          successfulRows: u.successfulRows,
+          duplicateRows: u.duplicateRows,
+          failedRows: u.failedRows,
+          status: u.status,
+          createdAt: typeof u.createdAt === 'string' ? u.createdAt : new Date(u.createdAt).toISOString(),
+          aiAutoScored: !!u.aiAutoScored,
+        }))
+        setUploads(list)
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to load uploads')
+          setUploads([])
+        }
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    })()
+    return () => { cancelled = true }
+  }, [refreshKey])
+
+  return (
+    <div className="p-6 space-y-6 bg-[#fcf8ec] min-h-screen">
+      {/* Header with Upload NEW CSV on tab */}
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold text-black">CSV Uploads</h1>
+          <p className="text-gray-500">Track your bulk lead imports with detailed history</p>
+        </div>
+        <Button className="btn-gold gap-2" onClick={onUploadCSV}>
+          <Upload className="w-4 h-4" />
+          Upload NEW CSV
+        </Button>
+      </div>
+
+      {error && (
+        <div className="rounded-lg border border-red-200 bg-red-50 p-4 flex items-center gap-2 text-red-800">
+          <AlertCircle className="w-5 h-5 shrink-0" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      {loading && (
+        <div className="flex items-center justify-center py-12 text-gray-500">
+          <RefreshCw className="w-6 h-6 animate-spin mr-2" />
+          Loading uploads…
+        </div>
+      )}
+
+      {!loading && !error && uploads.length === 0 && (
+        <Card className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)]">
+          <CardContent className="p-12 text-center">
+            <FileSpreadsheet className="w-12 h-12 text-[#2563EB]/60 mx-auto mb-4" />
+            <p className="text-gray-600">No uploads yet. Import leads from a CSV to see history here.</p>
+            <Button className="btn-gold mt-4 gap-2" onClick={onUploadCSV}>
+              <Upload className="w-4 h-4" />
+              Upload CSV
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+      
+      {/* Upload History */}
+      {!loading && uploads.length > 0 && (
+      <div className="space-y-4">
+        {uploads.map((upload) => (
+          <Card key={upload.id} className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] shadow-sm">
+            <CardContent className="p-5">
+              <div className="flex items-start justify-between">
+                <div className="flex items-start gap-4">
+                  <div className="w-12 h-12 rounded-lg bg-[#2563EB]/20 flex items-center justify-center">
+                    <FileSpreadsheet className="w-6 h-6 text-[#2563EB]" />
+                  </div>
+                  <div>
+                    <h3 className="text-sm font-medium text-black">{upload.fileName}</h3>
+                    <p className="text-xs text-gray-500 mt-1">
+                      <span suppressHydrationWarning>Uploaded {new Date(upload.createdAt).toLocaleDateString()} at {new Date(upload.createdAt).toLocaleTimeString()}</span>
+                    </p>
+                    <div className="flex items-center gap-4 mt-2">
+                      <span className="text-xs text-gray-500">{(upload.fileSize / 1024).toFixed(1)} KB</span>
+                      <span className="text-xs text-gray-500">{upload.totalRows} rows</span>
+                      {upload.aiAutoScored && (
+                        <Badge variant="outline" className="text-xs border-[#2563EB]/50 text-[#2563EB]">
+                          <Sparkles className="w-3 h-3 mr-1" />
+                          AI Scored
+                        </Badge>
+                      )}
+                    </div>
+                  </div>
+                </div>
+                
+                <div className="flex items-center gap-4">
+                  <div className="text-right">
+                    <div className="flex items-center gap-3 text-xs">
+                      <span className="text-emerald-600">{upload.successfulRows} imported</span>
+                      {upload.duplicateRows > 0 && (
+                        <span className="text-amber-600">{upload.duplicateRows} duplicates</span>
+                      )}
+                      {upload.failedRows > 0 && (
+                        <span className="text-red-600">{upload.failedRows} failed</span>
+                      )}
+                    </div>
+                  </div>
+                  <Badge
+                    variant="outline"
+                    className={cn(
+                      upload.status === "completed" && "border-emerald-500 text-emerald-600",
+                      upload.status === "processing" && "border-blue-500 text-blue-600",
+                      upload.status === "failed" && "border-red-500 text-red-600"
+                    )}
+                  >
+                    {upload.status}
+                  </Badge>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+      )}
+    </div>
+  )
+}
+
+// Linear Issue Priority Helpers
+const priorityConfig: Record<number, { label: string; color: string }> = {
+  0: { label: "No priority", color: "#6B7280" },
+  1: { label: "Urgent", color: "#DC2626" },
+  2: { label: "High", color: "#F59E0B" },
+  3: { label: "Medium", color: "#3B82F6" },
+  4: { label: "Low", color: "#6B7280" },
+}
+
+interface LinearIssue {
+  id: string
+  identifier: string
+  title: string
+  description?: string
+  url: string
+  state: { name: string; color: string } | null
+  priority: number
+  priorityLabel: string
+  assignee: { name: string; email: string; avatarUrl?: string } | null
+  team: { name: string; key: string } | null
+  labels: { name: string; color: string }[]
+  createdAt: string
+  updatedAt: string
+  dueDate: string | null
+}
+
+interface LinearTeam {
+  id: string
+  name: string
+  key: string
+  description?: string
+}
+
+// Linear View - full issue tracker integration
+function LinearView({ onCreateIssue }: { onCreateIssue: () => void }) {
+  const [issues, setIssues] = useState<LinearIssue[]>([])
+  const [teams, setTeams] = useState<LinearTeam[]>([])
+  const [loading, setLoading] = useState(true)
+  const [configured, setConfigured] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [selectedTeam, setSelectedTeam] = useState<string>("all")
+  const [selectedIssue, setSelectedIssue] = useState<LinearIssue | null>(null)
+
+  const fetchData = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const statusRes = await fetch("/api/linear?action=status")
+      const statusData = await statusRes.json()
+      if (!statusData.configured) {
+        setConfigured(false)
+        setLoading(false)
+        return
+      }
+      setConfigured(true)
+      setTeams(statusData.teams || [])
+
+      const params = new URLSearchParams({ action: "issues", first: "50" })
+      if (selectedTeam !== "all") params.set("teamId", selectedTeam)
+      const issuesRes = await fetch(`/api/linear?${params}`)
+      const issuesData = await issuesRes.json()
+      if (issuesData.error) throw new Error(issuesData.error)
+      setIssues(issuesData.issues || [])
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load Linear data")
+    } finally {
+      setLoading(false)
+    }
+  }, [selectedTeam])
+
+  useEffect(() => { fetchData() }, [fetchData])
+
+  if (!configured) {
+    return (
+      <div className="p-6 space-y-6 bg-[#fcf8ec] min-h-screen">
+        <div>
+          <h1 className="text-2xl font-bold text-black">Linear Integration</h1>
+          <p className="text-gray-500">Connect your Linear workspace to sync issues</p>
+        </div>
+        <Card className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] shadow-sm">
+          <CardContent className="p-8 text-center space-y-4">
+            <div className="w-16 h-16 rounded-2xl bg-[#5E6AD2]/10 flex items-center justify-center mx-auto">
+              <SquareKanban className="w-8 h-8 text-[#5E6AD2]" />
+            </div>
+            <h3 className="text-lg font-semibold text-black">Linear Not Connected</h3>
+            <p className="text-gray-500 max-w-md mx-auto">
+              Add your Linear API key to the <code className="bg-[#EEF2F7] px-1.5 py-0.5 rounded text-sm">.env</code> file to enable the integration.
+              Get your key from <a href="https://linear.app/settings/api" target="_blank" rel="noopener noreferrer" className="text-[#5E6AD2] underline">Linear Settings &rarr; API</a>.
+            </p>
+            <div className="bg-[#EEF2F7] rounded-lg p-4 text-left max-w-sm mx-auto">
+              <p className="text-xs text-gray-500 mb-1">Add to your .env file:</p>
+              <code className="text-sm text-black">LINEAR_API_KEY=&quot;lin_api_...&quot;</code>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  return (
+    <div className="p-6 space-y-6 bg-[#fcf8ec] min-h-screen">
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold text-black flex items-center gap-2">
+            <SquareKanban className="w-6 h-6 text-[#5E6AD2]" />
+            Linear Issues
+          </h1>
+          <p className="text-gray-500">Track and manage issues from your Linear workspace</p>
+        </div>
+        <div className="flex items-center gap-3">
+          <Button
+            variant="outline"
+            className="border-[rgba(31,42,54,0.08)] text-gray-600 hover:bg-[#EEF2F7] gap-2"
+            onClick={fetchData}
+            disabled={loading}
+          >
+            <RefreshCw className={cn("w-4 h-4", loading && "animate-spin")} />
+            Refresh
+          </Button>
+          <Button className="gap-2 bg-[#5E6AD2] hover:bg-[#4C56B8] text-white" onClick={onCreateIssue}>
+            <Plus className="w-4 h-4" />
+            New Issue
+          </Button>
+        </div>
+      </div>
+
+      {/* Stats cards */}
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+        {[
+          { title: "Total Issues", value: issues.length, icon: SquareKanban, color: "#5E6AD2" },
+          { title: "In Progress", value: issues.filter(i => i.state?.name?.toLowerCase().includes("progress")).length, icon: Play, color: "#F59E0B" },
+          { title: "Urgent/High", value: issues.filter(i => i.priority <= 2 && i.priority > 0).length, icon: AlertTriangle, color: "#DC2626" },
+          { title: "Teams", value: teams.length, icon: Users, color: "#059669" },
+        ].map((stat) => (
+          <Card key={stat.title} className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] shadow-sm">
+            <CardContent className="p-4">
+              <div className="flex items-center gap-3">
+                <div className="w-10 h-10 rounded-lg flex items-center justify-center" style={{ backgroundColor: `${stat.color}15` }}>
+                  <stat.icon className="w-5 h-5" style={{ color: stat.color }} />
+                </div>
+                <div>
+                  <p className="text-2xl font-bold text-black">{stat.value}</p>
+                  <p className="text-sm text-gray-500">{stat.title}</p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {/* Filters */}
+      <div className="flex items-center gap-4 flex-wrap">
+        <div className="flex items-center gap-2">
+          <Filter className="w-4 h-4 text-gray-400" />
+          <Select value={selectedTeam} onValueChange={setSelectedTeam}>
+            <SelectTrigger className="w-[180px] bg-[#fcfcfc] border-[rgba(31,42,54,0.08)]">
+              <SelectValue placeholder="Filter by team" />
+            </SelectTrigger>
+            <SelectContent className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)]">
+              <SelectItem value="all">All Teams</SelectItem>
+              {teams.map((t) => (
+                <SelectItem key={t.id} value={t.id}>{t.name} ({t.key})</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      {/* Issues list */}
+      {error && (
+        <Card className="bg-red-50 border-red-200">
+          <CardContent className="p-4 text-red-700 text-sm">{error}</CardContent>
+        </Card>
+      )}
+
+      <Card className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] shadow-sm overflow-hidden">
+        {loading ? (
+          <div className="p-8 text-center text-gray-500">Loading issues from Linear...</div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full">
+              <thead>
+                <tr className="border-b border-[rgba(31,42,54,0.08)] bg-[#EEF2F7]">
+                  <th className="text-left p-4 text-sm font-medium text-gray-600">Issue</th>
+                  <th className="text-left p-4 text-sm font-medium text-gray-600">Status</th>
+                  <th className="text-left p-4 text-sm font-medium text-gray-600">Priority</th>
+                  <th className="text-left p-4 text-sm font-medium text-gray-600">Assignee</th>
+                  <th className="text-left p-4 text-sm font-medium text-gray-600">Labels</th>
+                  <th className="text-left p-4 text-sm font-medium text-gray-600">Updated</th>
+                  <th className="text-left p-4 text-sm font-medium text-gray-600"></th>
+                </tr>
+              </thead>
+              <tbody>
+                {issues.length === 0 ? (
+                  <tr>
+                    <td colSpan={7} className="p-8 text-center text-gray-500">
+                      No issues found. Create one or check your team filter.
+                    </td>
+                  </tr>
+                ) : (
+                  issues.map((issue) => {
+                    const pCfg = priorityConfig[issue.priority] ?? priorityConfig[0]
+                    return (
+                      <motion.tr
+                        key={issue.id}
+                        initial={{ opacity: 0 }}
+                        animate={{ opacity: 1 }}
+                        className="border-b border-[rgba(31,42,54,0.08)] hover:bg-[#fcf8ec] transition-colors cursor-pointer"
+                        onClick={() => setSelectedIssue(issue)}
+                      >
+                        <td className="p-4">
+                          <div>
+                            <div className="flex items-center gap-2">
+                              <span className="text-xs font-mono text-gray-400">{issue.identifier}</span>
+                              {issue.team && (
+                                <Badge variant="outline" className="text-xs border-[rgba(31,42,54,0.08)] text-gray-500">{issue.team.key}</Badge>
+                              )}
+                            </div>
+                            <p className="text-sm font-medium text-black mt-0.5 max-w-[300px] truncate">{issue.title}</p>
+                          </div>
+                        </td>
+                        <td className="p-4">
+                          {issue.state && (
+                            <div className="flex items-center gap-1.5">
+                              <Circle className="w-3 h-3 shrink-0" style={{ color: issue.state.color, fill: issue.state.color }} />
+                              <span className="text-sm text-gray-700">{issue.state.name}</span>
+                            </div>
+                          )}
+                        </td>
+                        <td className="p-4">
+                          <span className="text-xs font-medium px-2 py-0.5 rounded" style={{ backgroundColor: `${pCfg.color}15`, color: pCfg.color }}>
+                            {pCfg.label}
+                          </span>
+                        </td>
+                        <td className="p-4">
+                          {issue.assignee ? (
+                            <div className="flex items-center gap-2">
+                              <Avatar className="w-6 h-6">
+                                {issue.assignee.avatarUrl && <AvatarImage src={issue.assignee.avatarUrl} />}
+                                <AvatarFallback className="bg-[#5E6AD2] text-white text-xs">
+                                  {issue.assignee.name.split(" ").map(n => n[0]).join("")}
+                                </AvatarFallback>
+                              </Avatar>
+                              <span className="text-sm text-gray-600">{issue.assignee.name}</span>
+                            </div>
+                          ) : (
+                            <span className="text-sm text-gray-400">Unassigned</span>
+                          )}
+                        </td>
+                        <td className="p-4">
+                          <div className="flex items-center gap-1 flex-wrap">
+                            {issue.labels.slice(0, 2).map((l) => (
+                              <Badge key={l.name} variant="outline" className="text-xs" style={{ borderColor: l.color, color: l.color }}>
+                                {l.name}
+                              </Badge>
+                            ))}
+                            {issue.labels.length > 2 && (
+                              <span className="text-xs text-gray-400">+{issue.labels.length - 2}</span>
+                            )}
+                          </div>
+                        </td>
+                        <td className="p-4">
+                          <span className="text-xs text-gray-500" suppressHydrationWarning>
+                            {new Date(issue.updatedAt).toLocaleDateString()}
+                          </span>
+                        </td>
+                        <td className="p-4">
+                          <a
+                            href={issue.url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-gray-400 hover:text-[#5E6AD2] transition-colors"
+                            onClick={(e) => e.stopPropagation()}
+                          >
+                            <ExternalLink className="w-4 h-4" />
+                          </a>
+                        </td>
+                      </motion.tr>
+                    )
+                  })
+                )}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Card>
+
+      {/* Issue detail modal */}
+      <Dialog open={!!selectedIssue} onOpenChange={() => setSelectedIssue(null)}>
+        <DialogContent className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] max-w-2xl">
+          {selectedIssue && (
+            <>
+              <DialogHeader>
+                <div className="flex items-center gap-2 text-sm text-gray-400 font-mono">
+                  {selectedIssue.identifier}
+                  {selectedIssue.team && (
+                    <Badge variant="outline" className="text-xs border-[rgba(31,42,54,0.08)]">{selectedIssue.team.name}</Badge>
+                  )}
+                </div>
+                <DialogTitle className="text-xl text-black">{selectedIssue.title}</DialogTitle>
+              </DialogHeader>
+              <div className="grid grid-cols-2 gap-6 py-4">
+                <div className="space-y-4">
+                  <div>
+                    <Label className="text-gray-500 text-xs">Status</Label>
+                    {selectedIssue.state && (
+                      <div className="flex items-center gap-2 mt-1">
+                        <Circle className="w-3 h-3" style={{ color: selectedIssue.state.color, fill: selectedIssue.state.color }} />
+                        <span className="text-black">{selectedIssue.state.name}</span>
+                      </div>
+                    )}
+                  </div>
+                  <div>
+                    <Label className="text-gray-500 text-xs">Priority</Label>
+                    <p className="text-black mt-1">{selectedIssue.priorityLabel}</p>
+                  </div>
+                  <div>
+                    <Label className="text-gray-500 text-xs">Assignee</Label>
+                    <p className="text-black mt-1">{selectedIssue.assignee?.name ?? "Unassigned"}</p>
+                  </div>
+                  {selectedIssue.dueDate && (
+                    <div>
+                      <Label className="text-gray-500 text-xs">Due Date</Label>
+                      <p className="text-black mt-1" suppressHydrationWarning>{new Date(selectedIssue.dueDate).toLocaleDateString()}</p>
+                    </div>
+                  )}
+                </div>
+                <div className="space-y-4">
+                  <div>
+                    <Label className="text-gray-500 text-xs">Labels</Label>
+                    <div className="flex flex-wrap gap-1 mt-1">
+                      {selectedIssue.labels.length > 0 ? selectedIssue.labels.map((l) => (
+                        <Badge key={l.name} variant="outline" className="text-xs" style={{ borderColor: l.color, color: l.color }}>
+                          {l.name}
+                        </Badge>
+                      )) : <span className="text-gray-400 text-sm">None</span>}
+                    </div>
+                  </div>
+                  {selectedIssue.description && (
+                    <div>
+                      <Label className="text-gray-500 text-xs">Description</Label>
+                      <p className="text-sm text-gray-700 mt-1 whitespace-pre-wrap max-h-40 overflow-y-auto">
+                        {selectedIssue.description}
+                      </p>
+                    </div>
+                  )}
+                </div>
+              </div>
+              <div className="flex justify-end gap-3">
+                <a href={selectedIssue.url} target="_blank" rel="noopener noreferrer">
+                  <Button className="gap-2 bg-[#5E6AD2] hover:bg-[#4C56B8] text-white">
+                    <ExternalLink className="w-4 h-4" />
+                    Open in Linear
+                  </Button>
+                </a>
+              </div>
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}
+
+function AutomationView() {
+  type AutomationItem = {
+    id: string
+    name: string
+    description: string | null
+    trigger: string
+    isActive: boolean
+    executionCount: number
+    lastExecutedAt?: string | null
+    actions: Array<Record<string, unknown>>
+  }
+
+  const [automations, setAutomations] = useState<AutomationItem[]>([])
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [showCreateDialog, setShowCreateDialog] = useState(false)
+  const [form, setForm] = useState({
+    name: '',
+    description: '',
+    trigger: 'lead_created',
+    actionType: 'create_task',
+    actionTarget: 'Follow up within 5 minutes',
+  })
+
+  const loadAutomations = useCallback(async () => {
+    setLoading(true)
+    try {
+      const res = await fetch('/api/automations')
+      const data = await res.json()
+      if (data.error) throw new Error(data.error)
+      setAutomations(Array.isArray(data.automations) ? data.automations : [])
+    } catch (error) {
+      toast({
+        title: 'Failed to load automations',
+        description: error instanceof Error ? error.message : 'Unknown error',
+        variant: 'destructive',
+      })
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void loadAutomations()
+  }, [loadAutomations])
+
+  const createAutomation = async () => {
+    if (!form.name.trim()) {
+      toast({ title: 'Name required', description: 'Give the automation a name.', variant: 'destructive' })
+      return
+    }
+
+    setSaving(true)
+    try {
+      const res = await fetch('/api/automations', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: form.name,
+          description: form.description || undefined,
+          trigger: form.trigger,
+          triggerConfig: { source: 'crm' },
+          conditions: {},
+          actions: [{ type: form.actionType, target: form.actionTarget }],
+          isActive: true,
+        }),
+      })
+      const data = await res.json()
+      if (data.error) throw new Error(data.error)
+      toast({ title: 'Automation created', description: `${form.name} is now active.` })
+      setShowCreateDialog(false)
+      setForm({
+        name: '',
+        description: '',
+        trigger: 'lead_created',
+        actionType: 'create_task',
+        actionTarget: 'Follow up within 5 minutes',
+      })
+      await loadAutomations()
+    } catch (error) {
+      toast({
+        title: 'Failed to create automation',
+        description: error instanceof Error ? error.message : 'Unknown error',
+        variant: 'destructive',
+      })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const updateAutomation = async (id: string, payload: Record<string, unknown>) => {
+    try {
+      const res = await fetch(`/api/automations?id=${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+      const data = await res.json()
+      if (data.error) throw new Error(data.error)
+      await loadAutomations()
+    } catch (error) {
+      toast({
+        title: 'Automation update failed',
+        description: error instanceof Error ? error.message : 'Unknown error',
+        variant: 'destructive',
+      })
+    }
+  }
+
+  const deleteAutomation = async (id: string) => {
+    try {
+      const res = await fetch(`/api/automations?id=${id}`, { method: 'DELETE' })
+      const data = await res.json()
+      if (data.error) throw new Error(data.error)
+      toast({ title: 'Automation removed', description: 'Automation deleted successfully.' })
+      await loadAutomations()
+    } catch (error) {
+      toast({
+        title: 'Delete failed',
+        description: error instanceof Error ? error.message : 'Unknown error',
+        variant: 'destructive',
+      })
+    }
+  }
+
+  const activeCount = automations.filter((automation) => automation.isActive).length
+
+  return (
+    <div className="p-6 space-y-6 bg-[#fcf8ec] min-h-screen">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-black">AI Automation</h1>
+          <p className="text-gray-500">Automate your workflows with intelligent triggers</p>
+        </div>
+        <Button
+          className="btn-gold gap-2"
+          onClick={() => setShowCreateDialog(true)}
+        >
+          <Plus className="w-4 h-4" />
+          Create Automation
+        </Button>
+      </div>
+      
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        {[
+          { title: "Active Automations", value: activeCount, icon: Zap },
+          { title: "Total Automations", value: automations.length, icon: Activity },
+          { title: "Runs Logged", value: automations.reduce((total, automation) => total + automation.executionCount, 0), icon: Brain },
+        ].map((stat) => (
+          <Card key={stat.title} className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] shadow-sm">
+            <CardContent className="p-4">
+              <div className="flex items-center gap-3">
+                <div className="w-10 h-10 rounded-lg bg-[#2563EB]/20 flex items-center justify-center">
+                  <stat.icon className="w-5 h-5 text-[#2563EB]" />
+                </div>
+                <div>
+                  <p className="text-2xl font-bold text-black">{stat.value}</p>
+                  <p className="text-sm text-gray-500">{stat.title}</p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <Card className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] shadow-sm">
+        <CardHeader>
+          <CardTitle className="text-black">Automation Library</CardTitle>
+          <CardDescription>Lead-triggered workflows that run inside your CRM organization.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <div className="text-sm text-gray-500">Loading automations…</div>
+          ) : automations.length === 0 ? (
+            <div className="rounded-lg border border-dashed border-[rgba(31,42,54,0.08)] p-6 text-sm text-gray-500">
+              No automations yet. Create a workflow for new leads, stage changes, or follow-up reminders.
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {automations.map((automation) => (
+                <div key={automation.id} className="rounded-lg border border-[rgba(31,42,54,0.08)] bg-[#EEF2F7] p-4 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-2">
+                      <p className="text-sm font-semibold text-black">{automation.name}</p>
+                      <Badge variant="outline" className={automation.isActive ? 'border-emerald-500 text-emerald-600' : 'border-gray-400 text-gray-500'}>
+                        {automation.isActive ? 'active' : 'paused'}
+                      </Badge>
+                      <Badge variant="outline" className="border-[#2563EB]/60 text-[#2563EB] capitalize">
+                        {automation.trigger.replaceAll('_', ' ')}
+                      </Badge>
+                    </div>
+                    <p className="text-sm text-gray-600 mt-1">{automation.description || 'No description provided.'}</p>
+                    <p className="text-xs text-gray-500 mt-2">
+                      {automation.actions.length} action{automation.actions.length === 1 ? '' : 's'} • {automation.executionCount} run{automation.executionCount === 1 ? '' : 's'}
+                      {automation.lastExecutedAt ? ` • Last run ${new Date(automation.lastExecutedAt).toLocaleString()}` : ''}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Switch checked={automation.isActive} onCheckedChange={(checked) => void updateAutomation(automation.id, { isActive: checked })} />
+                    <Button variant="outline" className="border-[rgba(31,42,54,0.08)]" onClick={() => void deleteAutomation(automation.id)}>
+                      Delete
+                    </Button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Dialog open={showCreateDialog} onOpenChange={setShowCreateDialog}>
+        <DialogContent className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)]">
+          <DialogHeader>
+            <DialogTitle className="text-black">Create Automation</DialogTitle>
+            <DialogDescription>Set a trigger and default action for your team workflow.</DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3">
+            <div>
+              <Label className="text-gray-600">Name</Label>
+              <Input className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" value={form.name} onChange={(e) => setForm((prev) => ({ ...prev, name: e.target.value }))} />
+            </div>
+            <div>
+              <Label className="text-gray-600">Description</Label>
+              <Textarea className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" value={form.description} onChange={(e) => setForm((prev) => ({ ...prev, description: e.target.value }))} />
+            </div>
+            <div>
+              <Label className="text-gray-600">Trigger</Label>
+              <Select value={form.trigger} onValueChange={(value) => setForm((prev) => ({ ...prev, trigger: value }))}>
+                <SelectTrigger className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]"><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="lead_created">Lead created</SelectItem>
+                  <SelectItem value="lead_scored">Lead scored</SelectItem>
+                  <SelectItem value="stage_changed">Pipeline stage changed</SelectItem>
+                  <SelectItem value="content_published">Content published</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <Label className="text-gray-600">Action type</Label>
+              <Select value={form.actionType} onValueChange={(value) => setForm((prev) => ({ ...prev, actionType: value }))}>
+                <SelectTrigger className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]"><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="create_task">Create task</SelectItem>
+                  <SelectItem value="send_sms">Send SMS</SelectItem>
+                  <SelectItem value="assign_owner">Assign owner</SelectItem>
+                  <SelectItem value="create_linear_issue">Create Linear issue</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <Label className="text-gray-600">Action target</Label>
+              <Input className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" value={form.actionTarget} onChange={(e) => setForm((prev) => ({ ...prev, actionTarget: e.target.value }))} placeholder="Task text, phone, owner email, issue title..." />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" className="border-[rgba(31,42,54,0.08)]" onClick={() => setShowCreateDialog(false)}>Cancel</Button>
+            <Button className="btn-gold" onClick={() => void createAutomation()} disabled={saving}>
+              {saving ? 'Saving...' : 'Create Automation'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}
+
+// ─── Scraping View ────────────────────────────────────────────────────────
+type ScrapeJobExt = {
+  id: string
+  name?: string
+  status: string
+  sourceUrl: string
+  stats?: { contactsFound?: number; pagesScraped?: number } | null
+  createdAt: string
+  error?: string | null
+}
+
+type ScrapeContactRow = {
+  id: string
+  firstName?: string | null
+  lastName?: string | null
+  email?: string | null
+  phone?: string | null
+  company?: string | null
+  title?: string | null
+  leadId?: string | null
+}
+
+function ScrapingView({ onNewJob }: { onNewJob: () => void }) {
+  const [jobs, setJobs] = useState<ScrapeJobExt[]>([])
+  const [contacts, setContacts] = useState<ScrapeContactRow[]>([])
+  const [loading, setLoading] = useState(true)
+  const [importing, setImporting] = useState<string | null>(null)
+  const [selectedJobId, setSelectedJobId] = useState<string | null>(null)
+  const [pageError, setPageError] = useState<string | null>(null)
+
+  const loadJobs = async () => {
+    try {
+      const res = await fetch(buildApiPath('/api/scrape'))
+      if (!res.ok) { setPageError('Failed to load scrape jobs'); return }
+      const data = await res.json() as { jobs?: ScrapeJobExt[] }
+      const list = data.jobs ?? []
+      setJobs(list)
+      if (list.length > 0 && !selectedJobId) setSelectedJobId(list[0].id)
+    } catch {
+      setPageError('Failed to load scrape jobs')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const loadContacts = async (jobId: string) => {
+    try {
+      const res = await fetch(buildApiPath(`/api/scrape?jobId=${encodeURIComponent(jobId)}&contacts=1`))
+      if (!res.ok) return
+      const data = await res.json() as { job?: { contacts?: ScrapeContactRow[] } }
+      setContacts(data.job?.contacts ?? [])
+    } catch { /* silent */ }
+  }
+
+  useEffect(() => {
+    void loadJobs()
+    const timer = setInterval(() => { void loadJobs() }, 8000)
+    return () => clearInterval(timer)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  useEffect(() => {
+    if (selectedJobId) void loadContacts(selectedJobId)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedJobId])
+
+  const importContact = async (contact: ScrapeContactRow) => {
+    setImporting(contact.id)
+    try {
+      const res = await fetch(buildApiPath('/api/leads'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          firstName: contact.firstName ?? '',
+          lastName: contact.lastName ?? '',
+          email: contact.email ?? '',
+          phone: contact.phone ?? '',
+          company: contact.company ?? '',
+          title: contact.title ?? '',
+          status: 'new',
+          source: 'scrape',
+        }),
+      })
+      if (res.ok) {
+        toast({ title: 'Lead imported', description: `${contact.firstName ?? ''} ${contact.lastName ?? ''}`.trim() || 'Contact added to leads' })
+        setContacts((prev) => prev.filter((c) => c.id !== contact.id))
+      } else {
+        toast({ title: 'Import failed', variant: 'destructive' })
+      }
+    } catch {
+      toast({ title: 'Import failed', variant: 'destructive' })
+    } finally {
+      setImporting(null)
+    }
+  }
+
+  const statusColor = (status: string) => {
+    if (status === 'completed') return 'text-emerald-600 bg-emerald-50 border-emerald-200'
+    if (status === 'running') return 'text-blue-600 bg-blue-50 border-blue-200'
+    if (status === 'failed') return 'text-red-600 bg-red-50 border-red-200'
+    return 'text-gray-600 bg-gray-50 border-gray-200'
+  }
+
+  const selectedJob = jobs.find((j) => j.id === selectedJobId)
+
+  return (
+    <div className="p-6 lg:p-8 space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-xl font-semibold text-[#1f2a36]">Lead Scraping</h2>
+          <p className="mt-1 text-sm text-[#1f2a36]/55">AI-powered lead discovery. Review scraped contacts here before importing them into your leads list.</p>
+        </div>
+        <Button onClick={onNewJob} className="bg-[linear-gradient(135deg,#557df5,#3a5fd9)] text-white shadow-[0_8px_20px_rgba(85,125,245,0.3)] hover:opacity-95">
+          <Plus className="mr-1.5 h-4 w-4" />
+          New Scrape Job
+        </Button>
+      </div>
+
+      {loading ? (
+        <div className="flex items-center justify-center py-20 text-[#1f2a36]/40">
+          <RefreshCw className="mr-2 h-5 w-5 animate-spin" />Loading jobs…
+        </div>
+      ) : pageError ? (
+        <div className="rounded-2xl border border-red-200 bg-red-50 p-6 text-center text-sm text-red-600">{pageError}</div>
+      ) : (
+        <div className="grid gap-6 lg:grid-cols-[280px_1fr]">
+          <div className="space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[#1f2a36]/40">Scrape Jobs</p>
+            {jobs.length === 0 ? (
+              <div className="rounded-2xl border border-dashed border-[rgba(31,42,54,0.12)] p-6 text-center text-sm text-[#1f2a36]/40">
+                No jobs yet. Click &ldquo;New Scrape Job&rdquo; or ask the AI Assistant to scrape leads for you.
+              </div>
+            ) : jobs.map((job) => (
+              <button
+                key={job.id}
+                onClick={() => { setSelectedJobId(job.id); void loadContacts(job.id) }}
+                className={cn(
+                  "w-full rounded-2xl border p-3.5 text-left transition-all",
+                  selectedJobId === job.id
+                    ? "border-[#557df5] bg-[#EEF5FF] shadow-sm"
+                    : "border-[rgba(31,42,54,0.08)] bg-white hover:border-[rgba(85,125,245,0.30)]"
+                )}
+              >
+                <p className="truncate text-sm font-medium text-[#1f2a36]">{job.name ?? job.sourceUrl?.slice(0, 40) ?? 'Scrape job'}</p>
+                <div className="mt-1.5 flex items-center gap-2">
+                  <span className={cn("rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase", statusColor(job.status))}>{job.status}</span>
+                  {job.stats?.contactsFound != null && (
+                    <span className="text-xs text-[#1f2a36]/45">{job.stats.contactsFound} contacts</span>
+                  )}
+                </div>
+                <p className="mt-1 text-xs text-[#1f2a36]/35">{new Date(job.createdAt).toLocaleString()}</p>
+              </button>
+            ))}
+          </div>
+
+          <div>
+            {!selectedJob ? (
+              <div className="flex h-64 items-center justify-center rounded-2xl border border-dashed border-[rgba(31,42,54,0.12)] text-sm text-[#1f2a36]/40">
+                Select a job to review scraped contacts
+              </div>
+            ) : (
+              <div className="rounded-2xl border border-[rgba(31,42,54,0.08)] bg-white shadow-sm overflow-hidden">
+                <div className="flex items-center justify-between border-b border-[rgba(31,42,54,0.06)] px-5 py-4">
+                  <div>
+                    <p className="font-medium text-[#1f2a36]">{selectedJob.name ?? selectedJob.sourceUrl}</p>
+                    <p className="text-xs text-[#1f2a36]/45">
+                      {contacts.length} contacts staged for review
+                      {selectedJob.status === 'running' && ' · Scraping in progress…'}
+                    </p>
+                  </div>
+                  {selectedJob.status === 'running' && <RefreshCw className="h-4 w-4 animate-spin text-[#557df5]" />}
+                </div>
+                {contacts.length === 0 ? (
+                  <div className="flex flex-col items-center justify-center py-16 text-center px-6">
+                    <p className="text-sm text-[#1f2a36]/50">
+                      {selectedJob.status === 'running'
+                        ? 'Contacts will appear here as the scraper finds them…'
+                        : selectedJob.status === 'failed'
+                        ? `Scrape failed: ${selectedJob.error ?? 'Unknown error'}`
+                        : 'No contacts found for this job.'}
+                    </p>
+                  </div>
+                ) : (
+                  <div className="overflow-x-auto">
+                    <table className="w-full text-sm">
+                      <thead>
+                        <tr className="border-b border-[rgba(31,42,54,0.06)]">
+                          {['Name', 'Title / Company', 'Email', 'Phone', 'Action'].map((h) => (
+                            <th key={h} className="whitespace-nowrap px-4 py-3 text-left text-xs font-semibold uppercase tracking-[0.12em] text-[#1f2a36]/40">{h}</th>
+                          ))}
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {contacts.map((c) => (
+                          <tr key={c.id} className="border-b border-[rgba(31,42,54,0.04)] last:border-0 hover:bg-[#f8f6f2]">
+                            <td className="px-4 py-3 font-medium text-[#1f2a36]">{[c.firstName, c.lastName].filter(Boolean).join(' ') || '—'}</td>
+                            <td className="px-4 py-3 text-[#1f2a36]/60">
+                              <p>{c.title ?? '—'}</p>
+                              {c.company && <p className="text-xs text-[#1f2a36]/40">{c.company}</p>}
+                            </td>
+                            <td className="px-4 py-3 text-[#1f2a36]/60">{c.email ?? '—'}</td>
+                            <td className="px-4 py-3 text-[#1f2a36]/60">{c.phone ?? '—'}</td>
+                            <td className="px-4 py-3">
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                className="h-7 rounded-lg border-[#557df5]/30 text-[#557df5] hover:bg-[#557df5]/8 text-xs"
+                                disabled={importing === c.id || !!c.leadId}
+                                onClick={() => void importContact(c)}
+                              >
+                                {c.leadId ? 'Imported' : importing === c.id ? 'Importing…' : 'Import Lead'}
+                              </Button>
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+
+function SocialMediaView() {
+  type QueueItem = {
+    id: string
+    platform: string
+    title: string | null
+    content: string
+    status: string
+    scheduledFor: string | null
+    publishedAt: string | null
+    createdAt: string
+    mediaUrls?: string[] | null
+  }
+
+  const [items, setItems] = useState<QueueItem[]>([])
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [showGenerateDialog, setShowGenerateDialog] = useState(false)
+  const [showMediaDialog, setShowMediaDialog] = useState(false)
+  const [platformFilter, setPlatformFilter] = useState('all')
+
+  const [topic, setTopic] = useState('')
+  const [platform, setPlatform] = useState('linkedin')
+  const [tone, setTone] = useState('professional')
+  const [generatedTitle, setGeneratedTitle] = useState('')
+  const [generatedContent, setGeneratedContent] = useState('')
+  const [generatedHashtags, setGeneratedHashtags] = useState<string[]>([])
+  const [bestTimeToPost, setBestTimeToPost] = useState('')
+  const [socialAccounts, setSocialAccounts] = useState<Array<{
+    id: string
+    platform: string
+    accountId: string
+    accountName: string | null
+    isActive: boolean
+    accessTokenConfigured?: boolean
+    lastSyncedAt?: string | null
+  }>>([])
+  const [showSocialAccountDialog, setShowSocialAccountDialog] = useState(false)
+  const [socialForm, setSocialForm] = useState({
+    platform: 'linkedin',
+    accountId: '',
+    accountName: '',
+    accessToken: '',
+  })
+
+  const [mediaTopic, setMediaTopic] = useState('')
+  const [mediaPlatform, setMediaPlatform] = useState('linkedin')
+  const [mediaPrompt, setMediaPrompt] = useState('')
+  const [mediaCaption, setMediaCaption] = useState('')
+  const [mediaCta, setMediaCta] = useState('')
+
+  const [composerTitle, setComposerTitle] = useState('')
+  const [composerContent, setComposerContent] = useState('')
+  const [composerPlatform, setComposerPlatform] = useState('linkedin')
+  const [composerScheduleAt, setComposerScheduleAt] = useState('')
+  const insuranceCampaignPacks = [
+    {
+      id: 'life-protection',
+      label: 'Life Protection Campaign',
+      topic: 'How term life insurance protects family income',
+      tone: 'educational',
+      defaultPlatform: 'facebook',
+      cta: 'Book your family protection review',
+    },
+    {
+      id: 'retirement-health',
+      label: 'Health + Retirement',
+      topic: 'Medicare timing and avoiding coverage gaps',
+      tone: 'authoritative',
+      defaultPlatform: 'linkedin',
+      cta: 'Schedule a Medicare planning call',
+    },
+    {
+      id: 'business-owner',
+      label: 'Business Owner Risk',
+      topic: 'Key person and buy-sell protection for small businesses',
+      tone: 'professional',
+      defaultPlatform: 'linkedin',
+      cta: 'Request a business risk strategy session',
+    },
+  ]
+
+  const fetchContent = useCallback(async () => {
+    setLoading(true)
+    try {
+      const query = platformFilter !== 'all' ? `?platform=${platformFilter}` : ''
+      const res = await fetch(`/api/content${query}`)
+      const data = await res.json()
+      if (data.error) throw new Error(data.error)
+      setItems(data.items || [])
+    } catch (error) {
+      toast({
+        title: 'Failed to load content queue',
+        description: error instanceof Error ? error.message : 'Unknown error',
+        variant: 'destructive',
+      })
+      setItems([])
+    } finally {
+      setLoading(false)
+    }
+  }, [platformFilter])
+
+  useEffect(() => {
+    void fetchContent()
+  }, [fetchContent])
+
+  const fetchSocialAccounts = useCallback(async () => {
+    try {
+      const res = await fetch('/api/social-accounts')
+      const data = await res.json()
+      if (data.error) throw new Error(data.error)
+      setSocialAccounts(Array.isArray(data.accounts) ? data.accounts : [])
+    } catch (error) {
+      toast({
+        title: 'Failed to load social accounts',
+        description: error instanceof Error ? error.message : 'Unknown error',
+        variant: 'destructive',
+      })
+      setSocialAccounts([])
+    }
+  }, [])
+
+  useEffect(() => {
+    void fetchSocialAccounts()
+  }, [fetchSocialAccounts])
+
+  const saveSocialAccount = async () => {
+    if (!socialForm.accountId.trim() || !socialForm.accessToken.trim()) {
+      toast({ title: 'Account details required', description: 'Enter the platform account id and access token.', variant: 'destructive' })
+      return
+    }
+
+    setSaving(true)
+    try {
+      const res = await fetch('/api/social-accounts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          platform: socialForm.platform,
+          accountId: socialForm.accountId,
+          accountName: socialForm.accountName || undefined,
+          accessToken: socialForm.accessToken,
+          isActive: true,
+        }),
+      })
+      const data = await res.json()
+      if (data.error) throw new Error(data.error)
+      toast({ title: 'Social account connected', description: `${socialForm.platform} is ready for publishing.` })
+      setShowSocialAccountDialog(false)
+      setSocialForm({ platform: 'linkedin', accountId: '', accountName: '', accessToken: '' })
+      await fetchSocialAccounts()
+    } catch (error) {
+      toast({
+        title: 'Failed to connect account',
+        description: error instanceof Error ? error.message : 'Unknown error',
+        variant: 'destructive',
+      })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const toggleSocialAccount = async (id: string, isActive: boolean) => {
+    try {
+      const res = await fetch(`/api/social-accounts?id=${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ isActive }),
+      })
+      const data = await res.json()
+      if (data.error) throw new Error(data.error)
+      await fetchSocialAccounts()
+    } catch (error) {
+      toast({
+        title: 'Failed to update account',
+        description: error instanceof Error ? error.message : 'Unknown error',
+        variant: 'destructive',
+      })
+    }
+  }
+
+  const removeSocialAccount = async (id: string) => {
+    try {
+      const res = await fetch(`/api/social-accounts?id=${id}`, { method: 'DELETE' })
+      const data = await res.json()
+      if (data.error) throw new Error(data.error)
+      await fetchSocialAccounts()
+    } catch (error) {
+      toast({
+        title: 'Failed to remove account',
+        description: error instanceof Error ? error.message : 'Unknown error',
+        variant: 'destructive',
+      })
+    }
+  }
+
+  const generateContent = async () => {
+    if (!topic.trim()) {
+      toast({ title: 'Topic required', description: 'Enter a topic to generate content.', variant: 'destructive' })
+      return
+    }
+
+    setSaving(true)
+    try {
+      const res = await fetch('/api/ai', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          action: 'generate-content',
+          data: { topic, platform, tone },
+        }),
+      })
+      const data = await res.json()
+      if (data.error) throw new Error(data.error)
+      setGeneratedTitle(data.title || topic)
+      setGeneratedContent(data.content || '')
+      setGeneratedHashtags(Array.isArray(data.hashtags) ? data.hashtags : [])
+      setBestTimeToPost(data.bestTimeToPost || '')
+      toast({ title: 'AI content generated', description: 'Review and save it as draft or scheduled post.' })
+    } catch (error) {
+      toast({
+        title: 'Content generation failed',
+        description: error instanceof Error ? error.message : 'Unknown error',
+        variant: 'destructive',
+      })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const generateMedia = async () => {
+    if (!mediaTopic.trim()) {
+      toast({ title: 'Topic required', description: 'Enter a topic to generate media prompt.', variant: 'destructive' })
+      return
+    }
+
+    setSaving(true)
+    try {
+      const res = await fetch('/api/ai', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          action: 'generate-media',
+          data: { topic: mediaTopic, platform: mediaPlatform, style: 'luxury, polished, insurance brand-safe' },
+        }),
+      })
+      const data = await res.json()
+      if (data.error) throw new Error(data.error)
+      setMediaPrompt(data.imagePrompt || '')
+      setMediaCaption(data.caption || '')
+      setMediaCta(data.cta || '')
+      toast({ title: 'Media prompt generated', description: 'Use this prompt in your image workflow.' })
+    } catch (error) {
+      toast({
+        title: 'Media generation failed',
+        description: error instanceof Error ? error.message : 'Unknown error',
+        variant: 'destructive',
+      })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const saveContent = async (payload: {
+    title?: string
+    content: string
+    platform: string
+    status: 'draft' | 'scheduled'
+    scheduledAt?: string
+    mediaUrls?: string[]
+  }) => {
+    if (!payload.content.trim()) {
+      toast({ title: 'Content required', description: 'Cannot save an empty post.', variant: 'destructive' })
+      return
+    }
+
+    setSaving(true)
+    try {
+      const res = await fetch('/api/content', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+      const data = await res.json()
+      if (data.error) throw new Error(data.error)
+      toast({ title: 'Post saved', description: payload.status === 'scheduled' ? 'Post scheduled successfully.' : 'Post saved as draft.' })
+      await fetchContent()
+    } catch (error) {
+      toast({
+        title: 'Save failed',
+        description: error instanceof Error ? error.message : 'Unknown error',
+        variant: 'destructive',
+      })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const removeItem = async (id: string) => {
+    try {
+      const res = await fetch(`/api/content?id=${id}`, { method: 'DELETE' })
+      const data = await res.json()
+      if (data.error) throw new Error(data.error)
+      toast({ title: 'Post removed', description: 'Content item deleted from queue.' })
+      await fetchContent()
+    } catch (error) {
+      toast({
+        title: 'Delete failed',
+        description: error instanceof Error ? error.message : 'Unknown error',
+        variant: 'destructive',
+      })
+    }
+  }
+
+  const filteredItems = items.filter((item) => platformFilter === 'all' || item.platform === platformFilter)
+  const applyCampaignPack = (pack: typeof insuranceCampaignPacks[number]) => {
+    setTopic(pack.topic)
+    setTone(pack.tone)
+    setPlatform(pack.defaultPlatform)
+    setComposerTitle(pack.label)
+    setComposerPlatform(pack.defaultPlatform)
+    setComposerContent(`${pack.topic}\n\n${pack.cta}`)
+    setShowGenerateDialog(true)
+  }
+
+  return (
+    <div className="p-6 space-y-6 bg-[#fcf8ec] min-h-screen">
+      <div className="flex flex-col lg:flex-row lg:items-center justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold text-black">Social Media</h1>
+          <p className="text-gray-500">Elite AI content studio with queue, scheduling, and media prompt generation</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" className="border-[#2563EB] text-[#2563EB] gap-2" onClick={() => setShowMediaDialog(true)}>
+            <ImageIcon className="w-4 h-4" />
+            Generate Media
+          </Button>
+          <Button className="btn-gold gap-2" onClick={() => setShowGenerateDialog(true)}>
+            <Sparkles className="w-4 h-4" />
+            Generate Content
+          </Button>
+        </div>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+        {insuranceCampaignPacks.map((pack) => (
+          <motion.button
+            key={pack.id}
+            whileHover={{ y: -2, scale: 1.01 }}
+            whileTap={{ scale: 0.99 }}
+            type="button"
+            onClick={() => applyCampaignPack(pack)}
+            className="text-left p-4 bg-[#fcfcfc] border border-[rgba(31,42,54,0.08)] rounded-xl shadow-sm hover:shadow-md transition-shadow"
+          >
+            <p className="text-sm font-semibold text-black">{pack.label}</p>
+            <p className="text-xs text-gray-500 mt-1">{pack.topic}</p>
+            <p className="text-xs text-[#64748B] mt-2">CTA: {pack.cta}</p>
+          </motion.button>
+        ))}
+      </div>
+
+      <Card className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] shadow-sm">
+        <CardHeader>
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <CardTitle className="text-black text-lg">Connected Social Accounts</CardTitle>
+              <CardDescription>Store the platform identities your scheduled content can publish through.</CardDescription>
+            </div>
+            <Button variant="outline" className="border-[rgba(31,42,54,0.08)]" onClick={() => setShowSocialAccountDialog(true)}>
+              <Plus className="w-4 h-4" />
+              Add account
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {socialAccounts.length === 0 ? (
+            <div className="rounded-lg border border-dashed border-[rgba(31,42,54,0.08)] p-6 text-sm text-gray-500">
+              No connected accounts yet. Add LinkedIn, Facebook, Instagram, or X credentials before using automated publishing.
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              {socialAccounts.map((account) => (
+                <div key={account.id} className="rounded-lg border border-[rgba(31,42,54,0.08)] bg-[#EEF2F7] p-4 space-y-3">
+                  <div className="flex items-center justify-between gap-3">
+                    <div>
+                      <p className="text-sm font-semibold text-black capitalize">{account.platform}</p>
+                      <p className="text-xs text-gray-500">{account.accountName || account.accountId}</p>
+                    </div>
+                    <Badge variant="outline" className={account.isActive ? 'border-emerald-500 text-emerald-600' : 'border-gray-400 text-gray-500'}>
+                      {account.isActive ? 'active' : 'paused'}
+                    </Badge>
+                  </div>
+                  <p className="text-xs text-gray-500">
+                    Token stored: {account.accessTokenConfigured ? 'yes' : 'no'}
+                    {account.lastSyncedAt ? ` • Synced ${new Date(account.lastSyncedAt).toLocaleString()}` : ''}
+                  </p>
+                  <div className="flex items-center justify-between gap-2">
+                    <Switch checked={account.isActive} onCheckedChange={(checked) => void toggleSocialAccount(account.id, checked)} />
+                    <Button variant="outline" className="border-[rgba(31,42,54,0.08)]" onClick={() => void removeSocialAccount(account.id)}>
+                      Remove
+                    </Button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
+        <Card className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] shadow-sm xl:col-span-1">
+          <CardHeader>
+            <CardTitle className="text-black text-lg">Manual Composer</CardTitle>
+            <CardDescription>Create, draft, and schedule premium brand posts.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <div>
+              <Label className="text-gray-600">Platform</Label>
+              <Select value={composerPlatform} onValueChange={setComposerPlatform}>
+                <SelectTrigger className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]"><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="linkedin">LinkedIn</SelectItem>
+                  <SelectItem value="twitter">Twitter/X</SelectItem>
+                  <SelectItem value="facebook">Facebook</SelectItem>
+                  <SelectItem value="instagram">Instagram</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <Label className="text-gray-600">Title</Label>
+              <Input className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" value={composerTitle} onChange={(e) => setComposerTitle(e.target.value)} placeholder="Post title (optional)" />
+            </div>
+            <div>
+              <Label className="text-gray-600">Post content</Label>
+              <Textarea className="mt-1 min-h-28 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" value={composerContent} onChange={(e) => setComposerContent(e.target.value)} placeholder="Write a high-converting post..." />
+            </div>
+            <div>
+              <Label className="text-gray-600">Schedule (optional)</Label>
+              <Input type="datetime-local" className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" value={composerScheduleAt} onChange={(e) => setComposerScheduleAt(e.target.value)} />
+            </div>
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                className="flex-1 border-[rgba(31,42,54,0.08)]"
+                onClick={() => void saveContent({ title: composerTitle, content: composerContent, platform: composerPlatform, status: 'draft' })}
+                disabled={saving}
+              >
+                Save Draft
+              </Button>
+              <Button
+                className="flex-1 btn-gold"
+                onClick={() => void saveContent({ title: composerTitle, content: composerContent, platform: composerPlatform, status: 'scheduled', scheduledAt: composerScheduleAt || undefined })}
+                disabled={saving}
+              >
+                Schedule
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] shadow-sm xl:col-span-2">
+          <CardHeader>
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <CardTitle className="text-black text-lg">Content Queue</CardTitle>
+                <CardDescription>Manage drafts, scheduled posts, and published content.</CardDescription>
+              </div>
+              <Select value={platformFilter} onValueChange={setPlatformFilter}>
+                <SelectTrigger className="w-[180px] bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]"><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All platforms</SelectItem>
+                  <SelectItem value="linkedin">LinkedIn</SelectItem>
+                  <SelectItem value="twitter">Twitter/X</SelectItem>
+                  <SelectItem value="facebook">Facebook</SelectItem>
+                  <SelectItem value="instagram">Instagram</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {loading ? (
+              <div className="py-10 text-center text-gray-500">Loading queue...</div>
+            ) : filteredItems.length === 0 ? (
+              <div className="py-10 text-center text-gray-500 border border-dashed border-[rgba(31,42,54,0.08)] rounded-lg">
+                No posts yet. Generate with AI or create your first draft.
+              </div>
+            ) : filteredItems.map((item) => (
+              <motion.div
+                key={item.id}
+                initial={{ opacity: 0, y: 6 }}
+                animate={{ opacity: 1, y: 0 }}
+                whileHover={{ y: -1 }}
+                className="p-4 bg-[#EEF2F7] border border-[rgba(31,42,54,0.08)] rounded-lg"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-2">
+                      <Badge variant="outline" className="capitalize border-[#2563EB]/60 text-[#64748B]">{item.platform}</Badge>
+                      <Badge variant="outline" className={cn(
+                        item.status === 'published' && 'border-emerald-500 text-emerald-600',
+                        item.status === 'scheduled' && 'border-blue-500 text-blue-600',
+                        item.status === 'draft' && 'border-gray-400 text-gray-600'
+                      )}>{item.status}</Badge>
+                    </div>
+                    <p className="text-sm font-semibold text-black mt-2">{item.title || 'Untitled post'}</p>
+                    <p className="text-sm text-gray-700 mt-1 whitespace-pre-wrap line-clamp-3">{item.content}</p>
+                    <p className="text-xs text-gray-500 mt-2">
+                      Created {new Date(item.createdAt).toLocaleString()}
+                      {item.scheduledFor ? ` • Scheduled ${new Date(item.scheduledFor).toLocaleString()}` : ''}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2 shrink-0">
+                    {item.status !== 'published' && (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="border-[rgba(31,42,54,0.08)]"
+                        onClick={() => void fetch(`/api/content?id=${item.id}`, {
+                          method: 'PATCH',
+                          headers: { 'Content-Type': 'application/json' },
+                          body: JSON.stringify({ status: 'published', publishedAt: new Date().toISOString() }),
+                        }).then(() => fetchContent())}
+                      >
+                        Publish
+                      </Button>
+                    )}
+                    <Button variant="ghost" size="icon" className="text-red-500 hover:text-red-700" onClick={() => void removeItem(item.id)}>
+                      <Trash2 className="w-4 h-4" />
+                    </Button>
+                  </div>
+                </div>
+              </motion.div>
+            ))}
+          </CardContent>
+        </Card>
+      </div>
+
+      <Dialog open={showGenerateDialog} onOpenChange={setShowGenerateDialog}>
+        <DialogContent className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] max-w-2xl">
+          <DialogHeader>
+            <DialogTitle className="text-black flex items-center gap-2"><Sparkles className="w-5 h-5 text-[#2563EB]" />Generate Social Content</DialogTitle>
+            <DialogDescription>Create premium content with AI and save directly to queue.</DialogDescription>
+          </DialogHeader>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+            <div className="md:col-span-3">
+              <Label className="text-gray-600">Topic</Label>
+              <Input className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" value={topic} onChange={(e) => setTopic(e.target.value)} placeholder="Life insurance myths families should stop believing" />
+            </div>
+            <div>
+              <Label className="text-gray-600">Platform</Label>
+              <Select value={platform} onValueChange={setPlatform}>
+                <SelectTrigger className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]"><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="linkedin">LinkedIn</SelectItem>
+                  <SelectItem value="twitter">Twitter/X</SelectItem>
+                  <SelectItem value="facebook">Facebook</SelectItem>
+                  <SelectItem value="instagram">Instagram</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <Label className="text-gray-600">Tone</Label>
+              <Select value={tone} onValueChange={setTone}>
+                <SelectTrigger className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]"><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="professional">Professional</SelectItem>
+                  <SelectItem value="authoritative">Authoritative</SelectItem>
+                  <SelectItem value="educational">Educational</SelectItem>
+                  <SelectItem value="friendly">Friendly</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="flex items-end">
+              <Button className="w-full btn-gold" onClick={() => void generateContent()} disabled={saving}>
+                {saving ? 'Generating...' : 'Generate'}
+              </Button>
+            </div>
+          </div>
+          <Separator />
+          <div className="space-y-3">
+            <div>
+              <Label className="text-gray-600">Generated title</Label>
+              <Input className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" value={generatedTitle} onChange={(e) => setGeneratedTitle(e.target.value)} />
+            </div>
+            <div>
+              <Label className="text-gray-600">Generated content</Label>
+              <Textarea className="mt-1 min-h-32 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" value={generatedContent} onChange={(e) => setGeneratedContent(e.target.value)} />
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {generatedHashtags.map((h) => (
+                <Badge key={h} variant="outline" className="border-[rgba(31,42,54,0.08)]">{h}</Badge>
+              ))}
+            </div>
+            {bestTimeToPost && <p className="text-xs text-gray-500">Best time to post: {bestTimeToPost}</p>}
+          </div>
+          <DialogFooter className="flex gap-2">
+            <Button
+              variant="outline"
+              className="border-[rgba(31,42,54,0.08)]"
+              onClick={() => void saveContent({ title: generatedTitle, content: generatedContent, platform, status: 'draft' })}
+              disabled={saving}
+            >
+              Save as Draft
+            </Button>
+            <Button
+              className="btn-gold"
+              onClick={() => void saveContent({ title: generatedTitle, content: generatedContent, platform, status: 'scheduled', scheduledAt: new Date(Date.now() + 60 * 60 * 1000).toISOString() })}
+              disabled={saving}
+            >
+              Quick Schedule (+1h)
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={showMediaDialog} onOpenChange={setShowMediaDialog}>
+        <DialogContent className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)] max-w-xl">
+          <DialogHeader>
+            <DialogTitle className="text-black flex items-center gap-2"><ImageIcon className="w-5 h-5 text-[#2563EB]" />Generate Media Prompt</DialogTitle>
+            <DialogDescription>Create image prompts and caption/CTA for high-performing visuals.</DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3">
+            <div>
+              <Label className="text-gray-600">Topic</Label>
+              <Input className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" value={mediaTopic} onChange={(e) => setMediaTopic(e.target.value)} placeholder="Family life insurance peace of mind visual" />
+            </div>
+            <div>
+              <Label className="text-gray-600">Platform</Label>
+              <Select value={mediaPlatform} onValueChange={setMediaPlatform}>
+                <SelectTrigger className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]"><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="linkedin">LinkedIn</SelectItem>
+                  <SelectItem value="instagram">Instagram</SelectItem>
+                  <SelectItem value="facebook">Facebook</SelectItem>
+                  <SelectItem value="twitter">Twitter/X</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <Button className="btn-gold w-full" onClick={() => void generateMedia()} disabled={saving}>
+              {saving ? 'Generating...' : 'Generate media pack'}
+            </Button>
+            <div>
+              <Label className="text-gray-600">Image prompt</Label>
+              <Textarea className="mt-1 min-h-24 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" value={mediaPrompt} onChange={(e) => setMediaPrompt(e.target.value)} />
+            </div>
+            <div>
+              <Label className="text-gray-600">Caption</Label>
+              <Textarea className="mt-1 min-h-16 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" value={mediaCaption} onChange={(e) => setMediaCaption(e.target.value)} />
+            </div>
+            <div>
+              <Label className="text-gray-600">CTA</Label>
+              <Input className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" value={mediaCta} onChange={(e) => setMediaCta(e.target.value)} />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              className="btn-gold"
+              onClick={() => void saveContent({
+                title: mediaTopic || 'AI media post',
+                content: `${mediaCaption}\n\nCTA: ${mediaCta}\n\n[MEDIA PROMPT]\n${mediaPrompt}`,
+                platform: mediaPlatform,
+                status: 'draft',
+                mediaUrls: [],
+              })}
+              disabled={saving}
+            >
+              Save media draft
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={showSocialAccountDialog} onOpenChange={setShowSocialAccountDialog}>
+        <DialogContent className="bg-[#fcfcfc] border-[rgba(31,42,54,0.08)]">
+          <DialogHeader>
+            <DialogTitle className="text-black">Connect Social Account</DialogTitle>
+            <DialogDescription>Store the platform account details this workspace should publish through.</DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3">
+            <div>
+              <Label className="text-gray-600">Platform</Label>
+              <Select value={socialForm.platform} onValueChange={(value) => setSocialForm((prev) => ({ ...prev, platform: value }))}>
+                <SelectTrigger className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]"><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="linkedin">LinkedIn</SelectItem>
+                  <SelectItem value="twitter">Twitter / X</SelectItem>
+                  <SelectItem value="facebook">Facebook</SelectItem>
+                  <SelectItem value="instagram">Instagram</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <Label className="text-gray-600">Account ID / page ID</Label>
+              <Input className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" value={socialForm.accountId} onChange={(e) => setSocialForm((prev) => ({ ...prev, accountId: e.target.value }))} />
+            </div>
+            <div>
+              <Label className="text-gray-600">Display name</Label>
+              <Input className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" value={socialForm.accountName} onChange={(e) => setSocialForm((prev) => ({ ...prev, accountName: e.target.value }))} />
+            </div>
+            <div>
+              <Label className="text-gray-600">Access token</Label>
+              <Input className="mt-1 bg-[#EEF2F7] border-[rgba(31,42,54,0.08)]" type="password" value={socialForm.accessToken} onChange={(e) => setSocialForm((prev) => ({ ...prev, accessToken: e.target.value }))} />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" className="border-[rgba(31,42,54,0.08)]" onClick={() => setShowSocialAccountDialog(false)}>Cancel</Button>
+            <Button className="btn-gold" onClick={() => void saveSocialAccount()} disabled={saving}>
+              {saving ? 'Saving...' : 'Save Account'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}
+
+// Main App
+export default function EliteCRM() {
+  const [activeView, setActiveView] = useState("dashboard")
+  const { authLoading, currentUser, signOut } = useWorkspaceSession()
+
+  // Onboarding state — only enabled once we know the user is authenticated
+  const isAuthenticated = !authLoading && !!currentUser
+  const { showWizard, showBanner, handleComplete, handleSkip, openWizard } = useOnboarding(isAuthenticated)
+
+  const {
+    commandPaletteOpen,
+    setCommandPaletteOpen,
+    showAddLeadDialog,
+    setShowAddLeadDialog,
+    showUploadDialog,
+    setShowUploadDialog,
+    showLinearIssueDialog,
+    setShowLinearIssueDialog,
+    linearIssuePrefill,
+    openLinearIssueDialog,
+    leadsRefreshKey,
+    uploadsRefreshKey,
+    handleLeadCreated,
+    showScrapeDialog,
+    setShowScrapeDialog,
+    scraping,
+    scrapeJobs,
+    scrapeForm,
+    setScrapeForm,
+    handleScrapeSubmit,
+    uploading,
+    handleFileUpload,
+  } = useWorkspaceOverlays()
+
+  const renderView = () => {
+    switch (activeView) {
+      case "dashboard": return <DashboardView />
+      case "leads": return <LeadsView onAddLead={() => setShowAddLeadDialog(true)} onUploadCSV={() => setShowUploadDialog(true)} onScrape={() => setShowScrapeDialog(true)} refreshKey={leadsRefreshKey} />
+      case "pipeline": return <PipelineView />
+      case "linear": return <LinearView onCreateIssue={() => openLinearIssueDialog()} />
+      case "uploads": return <UploadsView onUploadCSV={() => setShowUploadDialog(true)} refreshKey={uploadsRefreshKey} />
+      case "automation": return <AutomationView />
+      case "assistant": return <AiAssistantView onOpenAISettings={() => setActiveView("settings")} />
+      case "help": return <HelpCenterView onJumpToSettingsAI={() => setActiveView("settings")} />
+      case "scraping": return <ScrapingView onNewJob={() => setShowScrapeDialog(true)} />
+      case "sms": return <SocialMediaView />
+      case "social": return <SocialMediaView />
+      case "settings": return <SettingsView />
+      default: return <DashboardView />
+    }
+  }
+
+  if (authLoading) {
+    return (
+      <div className="min-h-screen bg-[radial-gradient(circle_at_top_right,rgba(85,125,245,0.12),transparent_30%),linear-gradient(180deg,#fcf8ec_0%,#eef3fb_48%,#fcf8ec_100%)] flex flex-col items-center justify-center gap-4">
+        <div className="flex h-16 w-16 items-center justify-center rounded-3xl bg-[linear-gradient(135deg,#557df5,#3a5fd9)] shadow-[0_16px_40px_rgba(85,125,245,0.32)]">
+          <Bot className="h-7 w-7 text-white" />
+        </div>
+        <div className="text-center">
+          <p className="text-xs font-semibold uppercase tracking-[0.22em] text-[#1f2a36]/45">King CRM Hub</p>
+          <p className="mt-1 text-sm text-[#1f2a36]/55 flex items-center gap-2">
+            <RefreshCw className="w-3.5 h-3.5 animate-spin" />
+            Loading workspace…
+          </p>
+        </div>
+      </div>
+    )
+  }
+  
+  return (
+    <>
+      {/* Onboarding wizard overlay */}
+      <AnimatePresence>
+        {showWizard && currentUser && (
+          <OnboardingWizard
+            organizationName={currentUser.organization?.name || "Your Organization"}
+            userName={currentUser.name}
+            onComplete={handleComplete}
+            onSkip={handleSkip}
+          />
+        )}
+      </AnimatePresence>
+
+    <AppShell
+      activeView={activeView}
+      setActiveView={setActiveView}
+      currentUser={currentUser}
+      onAddLead={() => setShowAddLeadDialog(true)}
+      onSignOut={() => void signOut()}
+    >
+      {/* Incomplete setup banner (shown after skipping or if wizard was dismissed) */}
+      <AnimatePresence>
+        {showBanner && !showWizard && (
+          <IncompleteSetupBanner onOpenWizard={openWizard} />
+        )}
+      </AnimatePresence>
+
+      <AnimatePresence mode="wait">
+        <motion.div
+          key={activeView}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.1 }}
+        >
+          {renderView()}
+        </motion.div>
+      </AnimatePresence>
+
+      <WorkspaceOverlays
+        showAddLeadDialog={showAddLeadDialog}
+        setShowAddLeadDialog={setShowAddLeadDialog}
+        onLeadCreated={handleLeadCreated}
+        showUploadDialog={showUploadDialog}
+        setShowUploadDialog={setShowUploadDialog}
+        uploading={uploading}
+        onFileUpload={handleFileUpload}
+        showScrapeDialog={showScrapeDialog}
+        setShowScrapeDialog={setShowScrapeDialog}
+        scrapeForm={scrapeForm}
+        setScrapeForm={setScrapeForm}
+        scraping={scraping}
+        onScrapeSubmit={() => void handleScrapeSubmit()}
+        scrapeJobs={scrapeJobs}
+        showLinearIssueDialog={showLinearIssueDialog}
+        setShowLinearIssueDialog={setShowLinearIssueDialog}
+        linearIssuePrefill={linearIssuePrefill}
+        commandPaletteOpen={commandPaletteOpen}
+        setCommandPaletteOpen={setCommandPaletteOpen}
+        onNavigate={setActiveView}
+        onAddLead={() => setShowAddLeadDialog(true)}
+        onUploadCSV={() => setShowUploadDialog(true)}
+      />
+    </AppShell>
+    </>
+  )
+}

--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -1,0 +1,1131 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+import { motion, AnimatePresence } from "framer-motion"
+import {
+  ArrowRight,
+  Bot,
+  Building2,
+  Check,
+  ChevronRight,
+  FileText,
+  Sparkles,
+  UserPlus,
+  X,
+  Zap,
+} from "lucide-react"
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Progress } from "@/components/ui/progress"
+import { toast } from "@/hooks/use-toast"
+
+// ============================================
+// TYPES
+// ============================================
+
+interface OnboardingWizardProps {
+  organizationName: string
+  userName: string | null
+  onComplete: () => void
+  onSkip: () => void
+}
+
+type StepStatus = "pending" | "active" | "done" | "skipped"
+
+interface StepDef {
+  id: string
+  title: string
+  subtitle: string
+  icon: React.ElementType
+  color: string
+  optional?: boolean
+}
+
+const STEPS: StepDef[] = [
+  {
+    id: "welcome",
+    title: "Welcome to KingCRMHub",
+    subtitle: "Let's get your workspace ready in under 3 minutes.",
+    icon: Sparkles,
+    color: "#557df5",
+  },
+  {
+    id: "organization",
+    title: "Set up your organization",
+    subtitle: "Confirm your organization details so everything looks right.",
+    icon: Building2,
+    color: "#3a5fd9",
+  },
+  {
+    id: "carrier",
+    title: "Add your first carrier",
+    subtitle: "Add a carrier to your library so the AI can match leads to plans.",
+    icon: FileText,
+    color: "#2563eb",
+  },
+  {
+    id: "lead",
+    title: "Add your first lead",
+    subtitle: "Drop in a contact to see how the CRM works end-to-end.",
+    icon: UserPlus,
+    color: "#0284c7",
+    optional: true,
+  },
+  {
+    id: "automation",
+    title: "Enable a quick automation",
+    subtitle: "Set a follow-up rule that fires when a new lead lands.",
+    icon: Zap,
+    color: "#0ea5e9",
+    optional: true,
+  },
+  {
+    id: "ai-setup",
+    title: "Set Up Your AI Assistant",
+    subtitle: "Connect an AI provider for sales coaching, scripts, and lead qualification.",
+    icon: Bot,
+    color: "#7c3aed",
+    optional: true,
+  },
+  {
+    id: "done",
+    title: "You're all set",
+    subtitle: "Your workspace is ready. Time to close deals.",
+    icon: Bot,
+    color: "#16a34a",
+  },
+]
+
+// ============================================
+// STEP INDICATOR
+// ============================================
+
+function StepIndicator({
+  steps,
+  currentIndex,
+  statuses,
+}: {
+  steps: StepDef[]
+  currentIndex: number
+  statuses: StepStatus[]
+}) {
+  const visibleSteps = steps.slice(0, -1) // exclude "done" step from indicator
+  return (
+    <div className="flex items-center gap-0">
+      {visibleSteps.map((step, index) => {
+        const status = statuses[index] ?? "pending"
+        const isLast = index === visibleSteps.length - 1
+        return (
+          <div key={step.id} className="flex items-center">
+            <div
+              className={cn(
+                "flex h-8 w-8 items-center justify-center rounded-full border-2 text-xs font-semibold transition-all duration-300",
+                status === "done" && "border-[#16a34a] bg-[#16a34a] text-white",
+                status === "active" && "border-[#557df5] bg-[#557df5] text-white shadow-[0_0_12px_rgba(85,125,245,0.5)]",
+                status === "skipped" && "border-amber-400 bg-amber-50 text-amber-600",
+                status === "pending" && "border-[rgba(31,42,54,0.15)] bg-white text-[rgba(31,42,54,0.35)]"
+              )}
+            >
+              {status === "done" ? (
+                <Check className="h-4 w-4" />
+              ) : (
+                <span>{index + 1}</span>
+              )}
+            </div>
+            {!isLast && (
+              <div
+                className={cn(
+                  "h-0.5 w-8 transition-all duration-500",
+                  index < currentIndex ? "bg-[#557df5]" : "bg-[rgba(31,42,54,0.1)]"
+                )}
+              />
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+// ============================================
+// STEP CONTENT PANELS
+// ============================================
+
+function WelcomeStep({
+  organizationName,
+  userName,
+  onNext,
+}: {
+  organizationName: string
+  userName: string | null
+  onNext: () => void
+}) {
+  return (
+    <div className="space-y-8 text-center">
+      <motion.div
+        initial={{ scale: 0.8, opacity: 0 }}
+        animate={{ scale: 1, opacity: 1 }}
+        transition={{ delay: 0.1, type: "spring", stiffness: 200 }}
+        className="mx-auto flex h-20 w-20 items-center justify-center rounded-3xl bg-[linear-gradient(135deg,#557df5,#3a5fd9)] shadow-[0_20px_40px_rgba(85,125,245,0.35)]"
+      >
+        <Sparkles className="h-9 w-9 text-white" />
+      </motion.div>
+
+      <div className="space-y-3">
+        <motion.h2
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.2 }}
+          className="text-3xl font-semibold tracking-[-0.03em] text-[#1f2a36]"
+        >
+          Welcome{userName ? `, ${userName.split(" ")[0]}` : ""}
+        </motion.h2>
+        <motion.p
+          initial={{ opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.3 }}
+          className="text-lg text-[#1f2a36]/60"
+        >
+          <span className="font-semibold text-[#557df5]">{organizationName}</span> is ready for setup.
+        </motion.p>
+        <motion.p
+          initial={{ opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.4 }}
+          className="mx-auto max-w-md text-sm leading-7 text-[#1f2a36]/55"
+        >
+          We'll walk you through 3–5 quick steps to get your pipeline, carrier library, and automations running.
+          Takes less than 3 minutes.
+        </motion.p>
+      </div>
+
+      <motion.div
+        initial={{ opacity: 0, y: 12 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.5 }}
+        className="mx-auto grid max-w-sm grid-cols-3 gap-3"
+      >
+        {[
+          { label: "AI Scoring", desc: "Auto-scored leads" },
+          { label: "Carrier AI", desc: "Smart plan matching" },
+          { label: "Pipeline", desc: "Drag & drop deals" },
+        ].map((feature) => (
+          <div
+            key={feature.label}
+            className="rounded-2xl border border-[rgba(31,42,54,0.08)] bg-[#f8f5ec] p-3 text-center"
+          >
+            <p className="text-xs font-semibold text-[#1f2a36]">{feature.label}</p>
+            <p className="mt-0.5 text-[11px] text-[#1f2a36]/50">{feature.desc}</p>
+          </div>
+        ))}
+      </motion.div>
+
+      <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 0.6 }}>
+        <Button
+          onClick={onNext}
+          className="h-12 rounded-2xl bg-[linear-gradient(135deg,#557df5,#3a5fd9)] px-8 text-white shadow-[0_12px_28px_rgba(85,125,245,0.28)] hover:opacity-95"
+        >
+          Get started
+          <ArrowRight className="ml-2 h-4 w-4" />
+        </Button>
+      </motion.div>
+    </div>
+  )
+}
+
+function OrganizationStep({
+  initialName,
+  onNext,
+  onSkip,
+}: {
+  initialName: string
+  onNext: () => void
+  onSkip: () => void
+}) {
+  const [name, setName] = useState(initialName)
+  const [logo, setLogo] = useState("")
+  const [saving, setSaving] = useState(false)
+
+  const handleSave = async () => {
+    if (!name.trim()) {
+      toast({ title: "Name required", description: "Enter your organization name.", variant: "destructive" })
+      return
+    }
+    setSaving(true)
+    try {
+      const res = await fetch("/api/settings/organization", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: name.trim(), logo: logo.trim() || undefined }),
+      })
+      const data = await res.json()
+      if (data.error) throw new Error(data.error)
+      toast({ title: "Organization updated", description: "Your workspace name has been saved." })
+      onNext()
+    } catch (error) {
+      toast({
+        title: "Save failed",
+        description: error instanceof Error ? error.message : "Unknown error",
+        variant: "destructive",
+      })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-4">
+        <div>
+          <Label className="mb-2 block text-xs font-semibold uppercase tracking-[0.16em] text-[#1f2a36]/52">
+            Organization name
+          </Label>
+          <Input
+            className="h-12 rounded-2xl border-[rgba(31,42,54,0.1)] bg-white shadow-sm"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="King Insurance Group"
+          />
+        </div>
+        <div>
+          <Label className="mb-2 block text-xs font-semibold uppercase tracking-[0.16em] text-[#1f2a36]/52">
+            Logo URL{" "}
+            <span className="text-[rgba(31,42,54,0.38)] normal-case font-normal tracking-normal">(optional)</span>
+          </Label>
+          <Input
+            className="h-12 rounded-2xl border-[rgba(31,42,54,0.1)] bg-white shadow-sm"
+            value={logo}
+            onChange={(e) => setLogo(e.target.value)}
+            placeholder="https://your-domain.com/logo.png"
+          />
+        </div>
+      </div>
+
+      <div className="flex gap-3">
+        <Button
+          variant="outline"
+          className="h-11 rounded-2xl border-[rgba(31,42,54,0.1)] text-[#1f2a36]/60"
+          onClick={onSkip}
+        >
+          Skip for now
+        </Button>
+        <Button
+          onClick={() => void handleSave()}
+          disabled={saving}
+          className="h-11 flex-1 rounded-2xl bg-[linear-gradient(135deg,#557df5,#3a5fd9)] text-white shadow-[0_8px_20px_rgba(85,125,245,0.22)] hover:opacity-95"
+        >
+          {saving ? "Saving…" : "Save & continue"}
+          <ChevronRight className="ml-1.5 h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+function CarrierStep({ onNext, onSkip }: { onNext: () => void; onSkip: () => void }) {
+  const [name, setName] = useState("")
+  const [website, setWebsite] = useState("")
+  const [notes, setNotes] = useState("")
+  const [saving, setSaving] = useState(false)
+
+  const handleSave = async () => {
+    if (!name.trim()) {
+      toast({ title: "Carrier name required", description: "Enter the carrier's name.", variant: "destructive" })
+      return
+    }
+    setSaving(true)
+    try {
+      const res = await fetch("/api/carriers", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: name.trim(),
+          website: website.trim() || undefined,
+          notes: notes.trim() || undefined,
+        }),
+      })
+      const data = await res.json()
+      if (data.error) throw new Error(data.error)
+      toast({ title: "Carrier added", description: `${name} is now in your carrier library.` })
+      onNext()
+    } catch (error) {
+      toast({
+        title: "Failed to add carrier",
+        description: error instanceof Error ? error.message : "Unknown error",
+        variant: "destructive",
+      })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-4">
+        <div>
+          <Label className="mb-2 block text-xs font-semibold uppercase tracking-[0.16em] text-[#1f2a36]/52">
+            Carrier name
+          </Label>
+          <Input
+            className="h-12 rounded-2xl border-[rgba(31,42,54,0.1)] bg-white shadow-sm"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="e.g. Nationwide, Mutual of Omaha"
+          />
+        </div>
+        <div>
+          <Label className="mb-2 block text-xs font-semibold uppercase tracking-[0.16em] text-[#1f2a36]/52">
+            Website{" "}
+            <span className="normal-case font-normal tracking-normal text-[rgba(31,42,54,0.38)]">(optional)</span>
+          </Label>
+          <Input
+            className="h-12 rounded-2xl border-[rgba(31,42,54,0.1)] bg-white shadow-sm"
+            value={website}
+            onChange={(e) => setWebsite(e.target.value)}
+            placeholder="https://carrier.com"
+          />
+        </div>
+        <div>
+          <Label className="mb-2 block text-xs font-semibold uppercase tracking-[0.16em] text-[#1f2a36]/52">
+            Notes{" "}
+            <span className="normal-case font-normal tracking-normal text-[rgba(31,42,54,0.38)]">(optional)</span>
+          </Label>
+          <Input
+            className="h-12 rounded-2xl border-[rgba(31,42,54,0.1)] bg-white shadow-sm"
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            placeholder="Specializes in term life, great for seniors…"
+          />
+        </div>
+      </div>
+
+      <div className="rounded-2xl border border-[rgba(85,125,245,0.18)] bg-[#f5f8ff] p-4 text-sm text-[#1f2a36]/65">
+        You can add more carriers and upload underwriting documents in{" "}
+        <span className="font-semibold text-[#557df5]">Settings → Carriers</span> at any time.
+      </div>
+
+      <div className="flex gap-3">
+        <Button
+          variant="outline"
+          className="h-11 rounded-2xl border-[rgba(31,42,54,0.1)] text-[#1f2a36]/60"
+          onClick={onSkip}
+        >
+          Skip for now
+        </Button>
+        <Button
+          onClick={() => void handleSave()}
+          disabled={saving}
+          className="h-11 flex-1 rounded-2xl bg-[linear-gradient(135deg,#557df5,#3a5fd9)] text-white shadow-[0_8px_20px_rgba(85,125,245,0.22)] hover:opacity-95"
+        >
+          {saving ? "Adding carrier…" : "Add carrier & continue"}
+          <ChevronRight className="ml-1.5 h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+function LeadStep({ onNext, onSkip }: { onNext: () => void; onSkip: () => void }) {
+  const [firstName, setFirstName] = useState("")
+  const [lastName, setLastName] = useState("")
+  const [email, setEmail] = useState("")
+  const [phone, setPhone] = useState("")
+  const [saving, setSaving] = useState(false)
+
+  const handleSave = async () => {
+    if (!firstName.trim() && !lastName.trim()) {
+      toast({ title: "Name required", description: "Enter at least a first or last name.", variant: "destructive" })
+      return
+    }
+    setSaving(true)
+    try {
+      const res = await fetch("/api/leads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          firstName: firstName.trim() || undefined,
+          lastName: lastName.trim() || undefined,
+          email: email.trim() || undefined,
+          phone: phone.trim() || undefined,
+          source: "manual",
+          status: "new",
+        }),
+      })
+      const data = await res.json()
+      if (data.error) throw new Error(data.error)
+      toast({ title: "Lead added", description: "Your first lead is in the system." })
+      onNext()
+    } catch (error) {
+      toast({
+        title: "Failed to add lead",
+        description: error instanceof Error ? error.message : "Unknown error",
+        variant: "destructive",
+      })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <Label className="mb-2 block text-xs font-semibold uppercase tracking-[0.16em] text-[#1f2a36]/52">
+            First name
+          </Label>
+          <Input
+            className="h-12 rounded-2xl border-[rgba(31,42,54,0.1)] bg-white shadow-sm"
+            value={firstName}
+            onChange={(e) => setFirstName(e.target.value)}
+            placeholder="Jane"
+          />
+        </div>
+        <div>
+          <Label className="mb-2 block text-xs font-semibold uppercase tracking-[0.16em] text-[#1f2a36]/52">
+            Last name
+          </Label>
+          <Input
+            className="h-12 rounded-2xl border-[rgba(31,42,54,0.1)] bg-white shadow-sm"
+            value={lastName}
+            onChange={(e) => setLastName(e.target.value)}
+            placeholder="Smith"
+          />
+        </div>
+        <div>
+          <Label className="mb-2 block text-xs font-semibold uppercase tracking-[0.16em] text-[#1f2a36]/52">
+            Email{" "}
+            <span className="normal-case font-normal tracking-normal text-[rgba(31,42,54,0.38)]">(optional)</span>
+          </Label>
+          <Input
+            type="email"
+            className="h-12 rounded-2xl border-[rgba(31,42,54,0.1)] bg-white shadow-sm"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="jane@email.com"
+          />
+        </div>
+        <div>
+          <Label className="mb-2 block text-xs font-semibold uppercase tracking-[0.16em] text-[#1f2a36]/52">
+            Phone{" "}
+            <span className="normal-case font-normal tracking-normal text-[rgba(31,42,54,0.38)]">(optional)</span>
+          </Label>
+          <Input
+            className="h-12 rounded-2xl border-[rgba(31,42,54,0.1)] bg-white shadow-sm"
+            value={phone}
+            onChange={(e) => setPhone(e.target.value)}
+            placeholder="(555) 123-4567"
+          />
+        </div>
+      </div>
+
+      <div className="flex gap-3">
+        <Button
+          variant="outline"
+          className="h-11 rounded-2xl border-[rgba(31,42,54,0.1)] text-[#1f2a36]/60"
+          onClick={onSkip}
+        >
+          Skip for now
+        </Button>
+        <Button
+          onClick={() => void handleSave()}
+          disabled={saving}
+          className="h-11 flex-1 rounded-2xl bg-[linear-gradient(135deg,#557df5,#3a5fd9)] text-white shadow-[0_8px_20px_rgba(85,125,245,0.22)] hover:opacity-95"
+        >
+          {saving ? "Adding lead…" : "Add lead & continue"}
+          <ChevronRight className="ml-1.5 h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+function AutomationStep({ onNext, onSkip }: { onNext: () => void; onSkip: () => void }) {
+  const [saving, setSaving] = useState(false)
+
+  const handleEnable = async () => {
+    setSaving(true)
+    try {
+      const res = await fetch("/api/automations", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: "New lead — immediate follow-up",
+          description: "Automatically flags new leads for a 5-minute follow-up reminder.",
+          trigger: "lead_created",
+          triggerConfig: { source: "crm" },
+          conditions: {},
+          actions: [{ type: "create_task", target: "Follow up within 5 minutes" }],
+          isActive: true,
+        }),
+      })
+      const data = await res.json()
+      if (data.error) throw new Error(data.error)
+      toast({ title: "Automation enabled", description: "Follow-up reminder is now active for new leads." })
+      onNext()
+    } catch (error) {
+      toast({
+        title: "Automation failed",
+        description: error instanceof Error ? error.message : "Unknown error",
+        variant: "destructive",
+      })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-2xl border border-[rgba(31,42,54,0.08)] bg-[#f8f5ec] p-5">
+        <div className="flex items-start gap-4">
+          <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-[#557df5]/12">
+            <Zap className="h-5 w-5 text-[#557df5]" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <p className="text-sm font-semibold text-[#1f2a36]">New lead — immediate follow-up</p>
+            <p className="mt-1 text-sm text-[#1f2a36]/60">
+              When a new lead is created, automatically create a task: "Follow up within 5 minutes".
+            </p>
+            <div className="mt-3 flex flex-wrap gap-2">
+              <span className="rounded-full border border-[rgba(85,125,245,0.25)] bg-[rgba(85,125,245,0.08)] px-3 py-1 text-xs text-[#557df5]">
+                Trigger: Lead created
+              </span>
+              <span className="rounded-full border border-[rgba(85,125,245,0.25)] bg-[rgba(85,125,245,0.08)] px-3 py-1 text-xs text-[#557df5]">
+                Action: Create task
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <p className="text-sm text-[#1f2a36]/55">
+        You can customize triggers and actions in the{" "}
+        <span className="font-semibold text-[#557df5]">AI Automation</span> section at any time.
+      </p>
+
+      <div className="flex gap-3">
+        <Button
+          variant="outline"
+          className="h-11 rounded-2xl border-[rgba(31,42,54,0.1)] text-[#1f2a36]/60"
+          onClick={onSkip}
+        >
+          Skip for now
+        </Button>
+        <Button
+          onClick={() => void handleEnable()}
+          disabled={saving}
+          className="h-11 flex-1 rounded-2xl bg-[linear-gradient(135deg,#557df5,#3a5fd9)] text-white shadow-[0_8px_20px_rgba(85,125,245,0.22)] hover:opacity-95"
+        >
+          {saving ? "Enabling…" : "Enable automation & finish"}
+          <ChevronRight className="ml-1.5 h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+function AiSetupStep({ onNext, onSkip }: { onNext: () => void; onSkip: () => void }) {
+  const [provider, setProvider] = useState<"groq" | "openai" | "anthropic">("groq")
+  const [apiKey, setApiKey] = useState("")
+  const [saving, setSaving] = useState(false)
+
+  const providers = [
+    {
+      id: "groq" as const,
+      name: "Groq",
+      badge: "Free",
+      desc: "Free API. Get a key at console.groq.com in 60 seconds.",
+      model: "Llama 3.3 70B",
+    },
+    {
+      id: "openai" as const,
+      name: "OpenAI",
+      badge: "GPT-4o",
+      desc: "Requires an OpenAI API key from platform.openai.com.",
+      model: "GPT-4o",
+    },
+    {
+      id: "anthropic" as const,
+      name: "Anthropic",
+      badge: "Claude",
+      desc: "Requires an Anthropic API key from console.anthropic.com.",
+      model: "Claude Sonnet",
+    },
+  ]
+
+  const handleSave = async () => {
+    if (!apiKey.trim()) {
+      toast({ title: "API key required", description: "Paste your API key to connect the AI assistant.", variant: "destructive" })
+      return
+    }
+    setSaving(true)
+    try {
+      const res = await fetch("/api/settings/ai", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ aiProvider: provider, aiApiKey: apiKey.trim() }),
+      })
+      const data = await res.json()
+      if (data.error) throw new Error(data.error)
+      toast({ title: "AI assistant connected", description: `${data.providerLabel} is now powering your AI assistant.` })
+      onNext()
+    } catch (error) {
+      toast({
+        title: "Failed to save",
+        description: error instanceof Error ? error.message : "Unknown error",
+        variant: "destructive",
+      })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="space-y-5">
+      <div className="rounded-2xl border border-[rgba(124,58,237,0.18)] bg-[#f8f5ff] px-4 py-3 text-sm text-[#4c1d95]">
+        <span className="font-semibold">Groq is 100% free</span> — sign up at{" "}
+        <span className="font-semibold">console.groq.com</span>, create an API key, paste it below. No credit card needed.
+      </div>
+
+      <div className="grid gap-2">
+        {providers.map((p) => (
+          <button
+            key={p.id}
+            onClick={() => setProvider(p.id)}
+            className={cn(
+              "flex w-full items-start gap-4 rounded-2xl border px-4 py-3.5 text-left transition-all",
+              provider === p.id
+                ? "border-[#7c3aed] bg-[#f5f0ff] shadow-[0_0_0_1px_#7c3aed]"
+                : "border-[rgba(31,42,54,0.1)] bg-white hover:border-[rgba(124,58,237,0.3)]"
+            )}
+          >
+            <div className={cn(
+              "mt-0.5 h-4 w-4 shrink-0 rounded-full border-2 transition-all",
+              provider === p.id ? "border-[#7c3aed] bg-[#7c3aed]" : "border-[rgba(31,42,54,0.25)]"
+            )} />
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-semibold text-[#1f2a36]">{p.name}</span>
+                <span className={cn(
+                  "rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide",
+                  p.id === "groq"
+                    ? "bg-[#dcfce7] text-[#15803d]"
+                    : "bg-[rgba(31,42,54,0.07)] text-[#1f2a36]/60"
+                )}>
+                  {p.badge}
+                </span>
+              </div>
+              <p className="mt-0.5 text-xs text-[#1f2a36]/55">{p.desc}</p>
+            </div>
+          </button>
+        ))}
+      </div>
+
+      <div>
+        <Label className="mb-2 block text-xs font-semibold uppercase tracking-[0.16em] text-[#1f2a36]/52">
+          API Key
+        </Label>
+        <Input
+          className="h-12 rounded-2xl border-[rgba(31,42,54,0.1)] bg-white font-mono text-sm shadow-sm"
+          value={apiKey}
+          onChange={(e) => setApiKey(e.target.value)}
+          placeholder={
+            provider === "groq"
+              ? "gsk_…"
+              : provider === "openai"
+              ? "sk-…"
+              : "sk-ant-…"
+          }
+          type="password"
+          autoComplete="off"
+        />
+      </div>
+
+      <div className="flex gap-3">
+        <Button
+          variant="outline"
+          className="h-11 rounded-2xl border-[rgba(31,42,54,0.1)] text-[#1f2a36]/60"
+          onClick={onSkip}
+        >
+          Skip for now
+        </Button>
+        <Button
+          onClick={() => void handleSave()}
+          disabled={saving}
+          className="h-11 flex-1 rounded-2xl bg-[linear-gradient(135deg,#7c3aed,#6d28d9)] text-white shadow-[0_8px_20px_rgba(124,58,237,0.22)] hover:opacity-95"
+        >
+          {saving ? "Connecting…" : "Connect AI & continue"}
+          <ChevronRight className="ml-1.5 h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+function DoneStep({
+  skippedCount,
+  onFinish,
+}: {
+  skippedCount: number
+  onFinish: () => void
+}) {
+  return (
+    <div className="space-y-8 text-center">
+      <motion.div
+        initial={{ scale: 0.7, opacity: 0 }}
+        animate={{ scale: 1, opacity: 1 }}
+        transition={{ type: "spring", stiffness: 180, delay: 0.05 }}
+        className="mx-auto flex h-20 w-20 items-center justify-center rounded-3xl bg-[linear-gradient(135deg,#16a34a,#15803d)] shadow-[0_20px_40px_rgba(22,163,74,0.3)]"
+      >
+        <Check className="h-9 w-9 text-white" />
+      </motion.div>
+
+      <div className="space-y-2">
+        <motion.h2
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.15 }}
+          className="text-3xl font-semibold tracking-[-0.03em] text-[#1f2a36]"
+        >
+          You're all set
+        </motion.h2>
+        <motion.p
+          initial={{ opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.25 }}
+          className="text-lg text-[#1f2a36]/60"
+        >
+          Your KingCRMHub workspace is ready to run.
+        </motion.p>
+        {skippedCount > 0 && (
+          <motion.p
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ delay: 0.35 }}
+            className="text-sm text-amber-600"
+          >
+            You skipped {skippedCount} step{skippedCount === 1 ? "" : "s"}. You can complete them anytime from
+            Settings.
+          </motion.p>
+        )}
+      </div>
+
+      <motion.div
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.4 }}
+        className="mx-auto grid max-w-sm grid-cols-1 gap-2 text-left"
+      >
+        {[
+          "Dashboard shows live stats and AI insights",
+          "Leads tab has your full contact table + AI scoring",
+          "Pipeline is your drag-and-drop kanban board",
+          "Settings → Carriers to upload documents for AI",
+          "Settings → AI Configuration to change your AI provider",
+        ].map((item) => (
+          <div key={item} className="flex items-center gap-3 text-sm text-[#1f2a36]/65">
+            <Check className="h-4 w-4 shrink-0 text-[#16a34a]" />
+            {item}
+          </div>
+        ))}
+      </motion.div>
+
+      <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 0.5 }}>
+        <Button
+          onClick={onFinish}
+          className="h-12 rounded-2xl bg-[linear-gradient(135deg,#16a34a,#15803d)] px-8 text-white shadow-[0_12px_28px_rgba(22,163,74,0.25)] hover:opacity-95"
+        >
+          Go to dashboard
+          <ArrowRight className="ml-2 h-4 w-4" />
+        </Button>
+      </motion.div>
+    </div>
+  )
+}
+
+// ============================================
+// MAIN WIZARD
+// ============================================
+
+export function OnboardingWizard({ organizationName, userName, onComplete, onSkip }: OnboardingWizardProps) {
+  const [currentStep, setCurrentStep] = useState(0)
+  const [statuses, setStatuses] = useState<StepStatus[]>(
+    STEPS.map((_, i) => (i === 0 ? "active" : "pending"))
+  )
+  const [skippedCount, setSkippedCount] = useState(0)
+
+  const totalSteps = STEPS.length
+  const isDoneStep = currentStep === totalSteps - 1
+  const progressPercent = isDoneStep ? 100 : Math.round((currentStep / (totalSteps - 2)) * 100)
+
+  const markStepDone = useCallback(
+    (stepIndex: number, wasSkipped = false) => {
+      setStatuses((prev) => {
+        const next = [...prev]
+        next[stepIndex] = wasSkipped ? "skipped" : "done"
+        if (stepIndex + 1 < next.length) next[stepIndex + 1] = "active"
+        return next
+      })
+      if (wasSkipped) setSkippedCount((c) => c + 1)
+    },
+    []
+  )
+
+  const advance = useCallback(
+    async (wasSkipped = false) => {
+      markStepDone(currentStep, wasSkipped)
+
+      const nextStep = currentStep + 1
+      setCurrentStep(nextStep)
+
+      // Persist progress to DB
+      try {
+        await fetch("/api/onboarding", {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            step: nextStep,
+            ...(nextStep === totalSteps - 1 ? { completed: true } : {}),
+          }),
+        })
+      } catch {
+        // Non-fatal
+      }
+    },
+    [currentStep, markStepDone, totalSteps]
+  )
+
+  const handleSkipAll = async () => {
+    try {
+      await fetch("/api/onboarding", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ completed: true, step: totalSteps - 1 }),
+      })
+    } catch {
+      // Non-fatal
+    }
+    onSkip()
+  }
+
+  const handleComplete = async () => {
+    try {
+      await fetch("/api/onboarding", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ completed: true, step: totalSteps - 1 }),
+      })
+    } catch {
+      // Non-fatal
+    }
+    onComplete()
+  }
+
+  const step = STEPS[currentStep]
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-[rgba(15,23,42,0.55)] backdrop-blur-sm">
+      <motion.div
+        initial={{ opacity: 0, scale: 0.95, y: 16 }}
+        animate={{ opacity: 1, scale: 1, y: 0 }}
+        exit={{ opacity: 0, scale: 0.95, y: 16 }}
+        transition={{ duration: 0.25, ease: "easeOut" }}
+        className="relative mx-4 w-full max-w-xl overflow-hidden rounded-[28px] border border-white/60 bg-[rgba(252,252,252,0.97)] shadow-[0_40px_100px_rgba(31,42,54,0.22)] backdrop-blur-xl"
+      >
+        {/* Skip all button */}
+        {!isDoneStep && (
+          <button
+            onClick={() => void handleSkipAll()}
+            className="absolute right-5 top-5 flex h-8 w-8 items-center justify-center rounded-full text-[#1f2a36]/35 transition-colors hover:bg-[rgba(31,42,54,0.06)] hover:text-[#1f2a36]"
+            aria-label="Skip setup"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        )}
+
+        {/* Header - progress */}
+        {!isDoneStep && currentStep > 0 && (
+          <div className="border-b border-[rgba(31,42,54,0.06)] px-8 py-5">
+            <div className="flex items-center justify-between gap-6">
+              <StepIndicator steps={STEPS} currentIndex={currentStep} statuses={statuses} />
+              <div className="min-w-[80px] text-right">
+                <p className="text-xs font-medium text-[#1f2a36]/45">
+                  Step {currentStep} of {totalSteps - 2}
+                </p>
+              </div>
+            </div>
+            <Progress value={progressPercent} className="mt-3 h-1.5 bg-[rgba(31,42,54,0.08)]" />
+          </div>
+        )}
+
+        {/* Step header (for non-welcome, non-done steps) */}
+        {currentStep > 0 && !isDoneStep && (
+          <div className="px-8 pt-6">
+            <div className="flex items-center gap-3">
+              <div
+                className="flex h-10 w-10 items-center justify-center rounded-2xl"
+                style={{ backgroundColor: `${step.color}18` }}
+              >
+                <step.icon className="h-5 w-5" style={{ color: step.color }} />
+              </div>
+              <div>
+                <h3 className="text-lg font-semibold text-[#1f2a36]">{step.title}</h3>
+                <p className="text-sm text-[#1f2a36]/55">{step.subtitle}</p>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Content */}
+        <div className={cn("px-8 pb-8", currentStep > 0 && !isDoneStep ? "pt-6" : "pt-8")}>
+          <AnimatePresence mode="wait">
+            <motion.div
+              key={currentStep}
+              initial={{ opacity: 0, x: 20 }}
+              animate={{ opacity: 1, x: 0 }}
+              exit={{ opacity: 0, x: -20 }}
+              transition={{ duration: 0.18, ease: "easeOut" }}
+            >
+              {currentStep === 0 && (
+                <WelcomeStep
+                  organizationName={organizationName}
+                  userName={userName}
+                  onNext={() => void advance(false)}
+                />
+              )}
+              {currentStep === 1 && (
+                <OrganizationStep
+                  initialName={organizationName}
+                  onNext={() => void advance(false)}
+                  onSkip={() => void advance(true)}
+                />
+              )}
+              {currentStep === 2 && (
+                <CarrierStep
+                  onNext={() => void advance(false)}
+                  onSkip={() => void advance(true)}
+                />
+              )}
+              {currentStep === 3 && (
+                <LeadStep
+                  onNext={() => void advance(false)}
+                  onSkip={() => void advance(true)}
+                />
+              )}
+              {currentStep === 4 && (
+                <AutomationStep
+                  onNext={() => void advance(false)}
+                  onSkip={() => void advance(true)}
+                />
+              )}
+              {currentStep === 5 && !isDoneStep && (
+                <AiSetupStep
+                  onNext={() => void advance(false)}
+                  onSkip={() => void advance(true)}
+                />
+              )}
+              {isDoneStep && (
+                <DoneStep
+                  skippedCount={skippedCount}
+                  onFinish={() => void handleComplete()}
+                />
+              )}
+            </motion.div>
+          </AnimatePresence>
+        </div>
+      </motion.div>
+    </div>
+  )
+}
+
+// ============================================
+// INCOMPLETE SETUP BANNER
+// ============================================
+
+export function IncompleteSetupBanner({ onOpenWizard }: { onOpenWizard: () => void }) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: -8 }}
+      animate={{ opacity: 1, y: 0 }}
+      className="mx-6 mt-4 flex items-center justify-between gap-4 rounded-2xl border border-amber-200 bg-amber-50 px-5 py-3.5"
+    >
+      <div className="flex items-center gap-3">
+        <div className="flex h-8 w-8 items-center justify-center rounded-xl bg-amber-100">
+          <Sparkles className="h-4 w-4 text-amber-600" />
+        </div>
+        <p className="text-sm font-medium text-amber-800">
+          Your workspace setup isn't complete yet.{" "}
+          <span className="text-amber-700">Finish setup to unlock the full CRM.</span>
+        </p>
+      </div>
+      <Button
+        size="sm"
+        onClick={onOpenWizard}
+        className="shrink-0 rounded-xl bg-amber-500 text-white hover:bg-amber-600"
+      >
+        Complete setup
+      </Button>
+    </motion.div>
+  )
+}
+
+// ============================================
+// HOOK: useOnboarding
+// ============================================
+
+export function useOnboarding(isAuthenticated: boolean) {
+  const [showWizard, setShowWizard] = useState(false)
+  const [showBanner, setShowBanner] = useState(false)
+  const [onboardingLoaded, setOnboardingLoaded] = useState(false)
+
+  useEffect(() => {
+    if (!isAuthenticated) return
+
+    let cancelled = false
+    ;(async () => {
+      try {
+        const res = await fetch("/api/onboarding")
+        const data = await res.json()
+        if (cancelled) return
+        if (!data.error) {
+          const completed: boolean = data.onboardingCompleted === true
+          setShowWizard(!completed)
+          setShowBanner(!completed)
+        }
+      } catch {
+        // Non-fatal — don't block the app
+      } finally {
+        if (!cancelled) setOnboardingLoaded(true)
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [isAuthenticated])
+
+  const handleComplete = useCallback(() => {
+    setShowWizard(false)
+    setShowBanner(false)
+  }, [])
+
+  const handleSkip = useCallback(() => {
+    setShowWizard(false)
+    // Keep the banner visible after skipping
+    setShowBanner(true)
+  }, [])
+
+  const openWizard = useCallback(() => {
+    setShowWizard(true)
+  }, [])
+
+  return {
+    showWizard,
+    showBanner,
+    onboardingLoaded,
+    handleComplete,
+    handleSkip,
+    openWizard,
+  }
+}

--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -28,6 +28,7 @@ import { toast } from "@/hooks/use-toast"
 interface OnboardingWizardProps {
   organizationName: string
   userName: string | null
+  initialStep?: number
   onComplete: () => void
   onSkip: () => void
 }
@@ -848,10 +849,15 @@ function DoneStep({
 // MAIN WIZARD
 // ============================================
 
-export function OnboardingWizard({ organizationName, userName, onComplete, onSkip }: OnboardingWizardProps) {
-  const [currentStep, setCurrentStep] = useState(0)
+export function OnboardingWizard({ organizationName, userName, initialStep = 0, onComplete, onSkip }: OnboardingWizardProps) {
+  const safeInitial = Math.max(0, Math.min(initialStep, STEPS.length - 1))
+  const [currentStep, setCurrentStep] = useState(safeInitial)
   const [statuses, setStatuses] = useState<StepStatus[]>(
-    STEPS.map((_, i) => (i === 0 ? "active" : "pending"))
+    STEPS.map((_, i) => {
+      if (i < safeInitial) return "done"
+      if (i === safeInitial) return "active"
+      return "pending"
+    })
   )
   const [skippedCount, setSkippedCount] = useState(0)
 
@@ -1078,6 +1084,7 @@ export function useOnboarding(isAuthenticated: boolean) {
   const [showWizard, setShowWizard] = useState(false)
   const [showBanner, setShowBanner] = useState(false)
   const [onboardingLoaded, setOnboardingLoaded] = useState(false)
+  const [onboardingStep, setOnboardingStep] = useState(0)
 
   useEffect(() => {
     if (!isAuthenticated) return
@@ -1090,6 +1097,7 @@ export function useOnboarding(isAuthenticated: boolean) {
         if (cancelled) return
         if (!data.error) {
           const completed: boolean = data.onboardingCompleted === true
+          setOnboardingStep(typeof data.onboardingStep === "number" ? data.onboardingStep : 0)
           setShowWizard(!completed)
           setShowBanner(!completed)
         }
@@ -1124,6 +1132,7 @@ export function useOnboarding(isAuthenticated: boolean) {
     showWizard,
     showBanner,
     onboardingLoaded,
+    onboardingStep,
     handleComplete,
     handleSkip,
     openWizard,

--- a/src/components/pricing/crm-pricing-page.tsx
+++ b/src/components/pricing/crm-pricing-page.tsx
@@ -1,0 +1,442 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  Check, X, Zap, Crown, Building2, Users, Shield, ChevronDown,
+  Loader2, Star, ArrowRight,
+} from "lucide-react";
+
+type Interval = "monthly" | "yearly";
+type PlanId = "free" | "starter" | "pro" | "enterprise";
+
+const PLANS = [
+  {
+    id: "free" as PlanId,
+    name: "Free",
+    monthlyPrice: 0,
+    yearlyPrice: 0,
+    description: "Get started with the basics. No credit card required.",
+    icon: Shield,
+    color: "border-gray-200",
+    btnClass: "bg-[#0f172a] text-white hover:bg-[#1e293b]",
+    features: [
+      { text: "1 user seat", included: true },
+      { text: "Up to 50 leads", included: true },
+      { text: "Basic pipeline view", included: true },
+      { text: "Email support", included: true },
+      { text: "AI Assistant", included: false },
+      { text: "SMS / Twilio", included: false },
+      { text: "Automation rules", included: false },
+      { text: "CSV import", included: false },
+      { text: "Lead scraping", included: false },
+      { text: "Underwriting AI Grader", included: false },
+    ],
+  },
+  {
+    id: "starter" as PlanId,
+    name: "Starter",
+    monthlyPrice: 39,
+    yearlyPrice: 31,
+    description: "Built for growing insurance teams ready to systematize.",
+    icon: Zap,
+    color: "border-[#557df5]/40",
+    btnClass: "bg-[#557df5] text-white hover:bg-[#3a5fd9]",
+    features: [
+      { text: "3 user seats", included: true },
+      { text: "Up to 500 leads", included: true },
+      { text: "Full Kanban pipeline", included: true },
+      { text: "CSV import", included: true },
+      { text: "Basic automation (5 rules)", included: true },
+      { text: "Email + chat support", included: true },
+      { text: "AI Assistant", included: false },
+      { text: "SMS / Twilio", included: false },
+      { text: "Lead scraping", included: false },
+      { text: "Underwriting AI Grader", included: false },
+    ],
+  },
+  {
+    id: "pro" as PlanId,
+    name: "Pro",
+    monthlyPrice: 99,
+    yearlyPrice: 79,
+    description: "The full operator stack. Everything your agency needs to dominate.",
+    icon: Crown,
+    color: "border-[#557df5]",
+    popular: true,
+    btnClass: "bg-gradient-to-r from-[#557df5] to-[#3a5fd9] text-white hover:brightness-110",
+    features: [
+      { text: "10 user seats", included: true },
+      { text: "Unlimited leads", included: true },
+      { text: "Full Kanban pipeline", included: true },
+      { text: "CSV import", included: true },
+      { text: "Full automation (unlimited)", included: true },
+      { text: "AI Assistant (unlimited)", included: true },
+      { text: "SMS via Twilio (BYOK)", included: true },
+      { text: "AI lead scraping", included: true },
+      { text: "Underwriting AI Grader", included: true },
+      { text: "Priority support", included: true },
+    ],
+  },
+  {
+    id: "enterprise" as PlanId,
+    name: "Enterprise",
+    monthlyPrice: 249,
+    yearlyPrice: 199,
+    description: "Custom scale for large agencies and regional carriers.",
+    icon: Building2,
+    color: "border-gray-200",
+    btnClass: "bg-[#0f172a] text-white hover:bg-[#1e293b]",
+    features: [
+      { text: "Unlimited seats", included: true },
+      { text: "Everything in Pro", included: true },
+      { text: "Custom onboarding", included: true },
+      { text: "Dedicated account manager", included: true },
+      { text: "SLA guarantee", included: true },
+      { text: "API access (coming soon)", included: true },
+      { text: "White-label options", included: true },
+      { text: "Custom integrations", included: true },
+      { text: "Invoice billing available", included: true },
+      { text: "Security review", included: true },
+    ],
+  },
+];
+
+const COMPARE_FEATURES = [
+  "User seats",
+  "Leads",
+  "Pipeline (Kanban)",
+  "CSV import",
+  "Automation rules",
+  "AI Assistant",
+  "SMS / Twilio",
+  "Lead scraping",
+  "Underwriting Grader",
+  "Priority support",
+];
+
+const FEATURE_MAP: Record<PlanId, (string | false)[]> = {
+  free:       ["1 seat", "50 leads", true, false, false, false, false, false, false, false],
+  starter:    ["3 seats", "500 leads", true, true, "5 rules", false, false, false, false, false],
+  pro:        ["10 seats", "Unlimited", true, true, "Unlimited", true, true, true, true, true],
+  enterprise: ["Unlimited", "Unlimited", true, true, "Unlimited", true, true, true, true, true],
+};
+
+const FAQ = [
+  {
+    q: "Can I upgrade or downgrade anytime?",
+    a: "Yes. Plan changes take effect at the start of your next billing cycle. Upgrades are prorated immediately.",
+  },
+  {
+    q: "Is there a free trial?",
+    a: "All paid plans include a 7-day free trial. No credit card required to start.",
+  },
+  {
+    q: "What payment methods do you accept?",
+    a: "All major credit and debit cards via Stripe. Invoice billing is available on Enterprise plans.",
+  },
+  {
+    q: "Can I cancel anytime?",
+    a: "Yes, cancel at any time with no cancellation fees. Your access continues through the end of the billing period.",
+  },
+  {
+    q: "Do you offer refunds?",
+    a: "We offer a 7-day money-back guarantee on all paid plans. Contact support within 7 days of your first charge.",
+  },
+];
+
+export function CrmPricingPage() {
+  const router = useRouter();
+  const [interval, setInterval] = useState<Interval>("monthly");
+  const [loadingPlan, setLoadingPlan] = useState<PlanId | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
+  const [openFaq, setOpenFaq] = useState<number | null>(null);
+
+  const showToast = (msg: string) => {
+    setToast(msg);
+    setTimeout(() => setToast(null), 5000);
+  };
+
+  const handleCta = async (planId: PlanId) => {
+    if (planId === "free") {
+      router.push("/auth");
+      return;
+    }
+    setLoadingPlan(planId);
+    try {
+      const res = await fetch("/api/billing/checkout", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ planId, interval }),
+      });
+      const data = (await res.json()) as { url?: string | null; message?: string };
+      if (data.url) {
+        window.location.href = data.url;
+      } else {
+        showToast(data.message ?? "Payments launching soon — stay tuned!");
+      }
+    } catch {
+      showToast("Something went wrong. Please try again.");
+    } finally {
+      setLoadingPlan(null);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-[radial-gradient(circle_at_top_right,rgba(85,125,245,0.08),transparent_40%),linear-gradient(180deg,#f9f5eb_0%,#eef3fb_100%)]">
+      {/* Nav */}
+      <nav className="flex items-center justify-between px-6 py-5 sm:px-10 lg:px-16">
+        <div className="flex items-center gap-3">
+          <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-[linear-gradient(135deg,#557df5,#3a5fd9)] shadow-md">
+            <Shield className="h-4 w-4 text-white" />
+          </div>
+          <span className="text-base font-bold tracking-tight text-[#0f172a]">King CRM Hub</span>
+        </div>
+        <button
+          onClick={() => router.push("/auth")}
+          className="flex h-9 items-center gap-1.5 rounded-xl border border-[#557df5]/40 px-4 text-sm font-medium text-[#557df5] transition hover:bg-[#557df5] hover:text-white"
+        >
+          Sign in <ArrowRight className="h-3.5 w-3.5" />
+        </button>
+      </nav>
+
+      {/* Hero */}
+      <section className="px-6 pb-12 pt-12 text-center sm:px-10 sm:pt-16">
+        <div className="mb-5 inline-flex items-center gap-2 rounded-full border border-[#557df5]/30 bg-white/70 px-4 py-1.5 text-xs font-semibold uppercase tracking-widest text-[#557df5] shadow-sm backdrop-blur-sm">
+          <Star className="h-3 w-3 fill-[#557df5]" />
+          Transparent pricing. No surprises.
+        </div>
+        <h1 className="mx-auto max-w-2xl text-4xl font-extrabold leading-tight tracking-tight text-[#0f172a] sm:text-5xl">
+          Plans built for{" "}
+          <span className="bg-gradient-to-r from-[#557df5] to-[#3a5fd9] bg-clip-text text-transparent">
+            insurance operators
+          </span>
+        </h1>
+        <p className="mx-auto mt-4 max-w-lg text-base text-[#475569] sm:text-lg">
+          From solo producers to regional agencies — pick the tier that matches your operation and scale without limits.
+        </p>
+
+        {/* Toggle */}
+        <div className="mt-8 inline-flex items-center gap-3 rounded-2xl border border-white/60 bg-white/80 p-1.5 shadow-sm backdrop-blur-sm">
+          <button
+            onClick={() => setInterval("monthly")}
+            className={`rounded-xl px-5 py-2.5 text-sm font-medium transition-all ${
+              interval === "monthly" ? "bg-[#0f172a] text-white shadow-sm" : "text-[#64748b] hover:text-[#0f172a]"
+            }`}
+          >
+            Monthly
+          </button>
+          <button
+            onClick={() => setInterval("yearly")}
+            className={`flex items-center gap-2 rounded-xl px-5 py-2.5 text-sm font-medium transition-all ${
+              interval === "yearly" ? "bg-[#0f172a] text-white shadow-sm" : "text-[#64748b] hover:text-[#0f172a]"
+            }`}
+          >
+            Yearly
+            <span className={`rounded-full px-2 py-0.5 text-[10px] font-bold transition-all ${
+              interval === "yearly" ? "bg-emerald-400/30 text-emerald-200" : "bg-emerald-100 text-emerald-700"
+            }`}>
+              Save 20%
+            </span>
+          </button>
+        </div>
+      </section>
+
+      {/* Plan Cards */}
+      <section className="mx-auto max-w-7xl px-4 pb-16 sm:px-6">
+        <div className="grid gap-5 sm:grid-cols-2 xl:grid-cols-4">
+          {PLANS.map((plan) => {
+            const Icon = plan.icon;
+            const price = interval === "monthly" ? plan.monthlyPrice : plan.yearlyPrice;
+            const isLoading = loadingPlan === plan.id;
+            return (
+              <div
+                key={plan.id}
+                className={`relative flex flex-col rounded-3xl border-2 bg-white p-6 shadow-sm transition-all hover:-translate-y-1 hover:shadow-lg ${plan.color} ${
+                  plan.popular ? "ring-2 ring-[#557df5]/30 shadow-[0_8px_32px_rgba(85,125,245,0.18)]" : ""
+                }`}
+              >
+                {plan.popular && (
+                  <div className="absolute -top-3.5 left-1/2 -translate-x-1/2">
+                    <span className="flex items-center gap-1 rounded-full bg-gradient-to-r from-[#557df5] to-[#3a5fd9] px-3.5 py-1 text-[11px] font-bold uppercase tracking-wider text-white shadow-md">
+                      <Crown className="h-3 w-3" />
+                      Most Popular
+                    </span>
+                  </div>
+                )}
+                <div className={`mb-4 flex h-10 w-10 items-center justify-center rounded-2xl ${plan.popular ? "bg-gradient-to-br from-[#557df5] to-[#3a5fd9]" : "bg-[#f1f5f9]"}`}>
+                  <Icon className={`h-5 w-5 ${plan.popular ? "text-white" : "text-[#557df5]"}`} />
+                </div>
+                <h3 className="text-lg font-bold text-[#0f172a]">{plan.name}</h3>
+                <p className="mt-1 text-sm leading-relaxed text-[#64748b]">{plan.description}</p>
+                <div className="my-5">
+                  <div className="flex items-end gap-1">
+                    <span className="text-4xl font-extrabold tracking-tight text-[#0f172a]">
+                      ${price}
+                    </span>
+                    {price > 0 && (
+                      <span className="mb-1 text-sm text-[#94a3b8]">/mo</span>
+                    )}
+                  </div>
+                  {price === 0 && (
+                    <span className="text-sm text-[#94a3b8]">Free forever</span>
+                  )}
+                  {interval === "yearly" && price > 0 && (
+                    <p className="mt-1 text-xs text-emerald-600">Billed ${price * 12}/year</p>
+                  )}
+                </div>
+                <button
+                  onClick={() => void handleCta(plan.id)}
+                  disabled={isLoading}
+                  className={`mb-6 flex h-10 w-full items-center justify-center gap-2 rounded-xl text-sm font-semibold transition-all disabled:opacity-60 ${plan.btnClass}`}
+                >
+                  {isLoading ? (
+                    <><Loader2 className="h-4 w-4 animate-spin" /> Processing…</>
+                  ) : plan.id === "free" ? (
+                    "Get started free"
+                  ) : plan.id === "enterprise" ? (
+                    "Contact sales"
+                  ) : (
+                    <>Start 7-day trial <ArrowRight className="h-3.5 w-3.5" /></>
+                  )}
+                </button>
+                <ul className="flex-1 space-y-2.5">
+                  {plan.features.map((f) => (
+                    <li key={f.text} className="flex items-start gap-2.5 text-sm">
+                      {f.included ? (
+                        <Check className="mt-0.5 h-4 w-4 shrink-0 text-emerald-500" />
+                      ) : (
+                        <X className="mt-0.5 h-4 w-4 shrink-0 text-[#cbd5e1]" />
+                      )}
+                      <span className={f.included ? "text-[#1e293b]" : "text-[#94a3b8]"}>{f.text}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      {/* Feature Comparison Table */}
+      <section className="mx-auto max-w-5xl px-4 pb-20 sm:px-6">
+        <h2 className="mb-8 text-center text-2xl font-bold text-[#0f172a]">Full feature comparison</h2>
+        <div className="overflow-hidden rounded-3xl border border-[#e2e8f0] bg-white shadow-sm">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-[#e2e8f0] bg-[#f8fafc]">
+                <th className="py-4 pl-6 text-left font-semibold text-[#64748b]">Feature</th>
+                {PLANS.map((p) => (
+                  <th key={p.id} className={`py-4 text-center font-bold ${p.popular ? "text-[#557df5]" : "text-[#0f172a]"}`}>
+                    {p.name}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {COMPARE_FEATURES.map((feature, i) => (
+                <tr key={feature} className={i % 2 === 0 ? "bg-white" : "bg-[#f8fafc]"}>
+                  <td className="py-3.5 pl-6 text-[#1e293b]">{feature}</td>
+                  {(["free", "starter", "pro", "enterprise"] as PlanId[]).map((planId) => {
+                    const val = FEATURE_MAP[planId][i];
+                    return (
+                      <td key={planId} className="py-3.5 text-center">
+                        {val === true ? (
+                          <Check className="mx-auto h-4 w-4 text-emerald-500" />
+                        ) : val === false ? (
+                          <X className="mx-auto h-4 w-4 text-[#cbd5e1]" />
+                        ) : (
+                          <span className="text-xs font-medium text-[#475569]">{val}</span>
+                        )}
+                      </td>
+                    );
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      {/* Testimonials */}
+      <section className="bg-[#0f172a] px-6 py-16 sm:px-10">
+        <h2 className="mb-10 text-center text-2xl font-bold text-white">What operators are saying</h2>
+        <div className="mx-auto grid max-w-5xl gap-5 sm:grid-cols-3">
+          {[
+            { name: "Marcus T.", role: "Independent Producer, TX", quote: "Went from juggling spreadsheets to having a real system in one afternoon. The pipeline alone is worth it." },
+            { name: "Dena R.", role: "Agency Owner, FL", quote: "The AI assistant is legitimately useful. It knows insurance ops, not just generic CRM fluff." },
+            { name: "James P.", role: "Sales Manager, GA", quote: "CSV import + lead scraping cut our prospecting time by 60%. The team finally has a real workflow." },
+          ].map((t) => (
+            <div key={t.name} className="rounded-2xl border border-white/10 bg-white/5 p-6">
+              <div className="mb-3 flex gap-0.5">
+                {Array.from({ length: 5 }).map((_, i) => (
+                  <Star key={i} className="h-3.5 w-3.5 fill-[#557df5] text-[#557df5]" />
+                ))}
+              </div>
+              <p className="mb-4 text-sm leading-relaxed text-white/75">&ldquo;{t.quote}&rdquo;</p>
+              <p className="text-sm font-semibold text-white">{t.name}</p>
+              <p className="text-xs text-white/50">{t.role}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* FAQ */}
+      <section className="mx-auto max-w-3xl px-6 py-20 sm:px-10">
+        <h2 className="mb-8 text-center text-2xl font-bold text-[#0f172a]">Frequently asked questions</h2>
+        <div className="space-y-3">
+          {FAQ.map((item, i) => (
+            <div key={i} className="overflow-hidden rounded-2xl border border-[#e2e8f0] bg-white">
+              <button
+                onClick={() => setOpenFaq(openFaq === i ? null : i)}
+                className="flex w-full items-center justify-between px-6 py-4 text-left text-sm font-semibold text-[#0f172a] hover:bg-[#f8fafc]"
+              >
+                {item.q}
+                <ChevronDown className={`h-4 w-4 shrink-0 text-[#64748b] transition-transform ${openFaq === i ? "rotate-180" : ""}`} />
+              </button>
+              {openFaq === i && (
+                <div className="border-t border-[#e2e8f0] px-6 py-4 text-sm leading-relaxed text-[#475569]">
+                  {item.a}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Bottom CTA */}
+      <section className="bg-gradient-to-br from-[#557df5] to-[#3a5fd9] px-6 py-16 text-center sm:px-10">
+        <h2 className="text-3xl font-bold text-white">Ready to run a tighter operation?</h2>
+        <p className="mx-auto mt-3 max-w-md text-base text-white/80">
+          Start free. Upgrade when you&apos;re ready. No long-term contracts.
+        </p>
+        <div className="mt-8 flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
+          <button
+            onClick={() => router.push("/auth")}
+            className="flex h-12 items-center gap-2 rounded-2xl bg-white px-8 text-sm font-bold text-[#557df5] shadow-lg transition hover:shadow-xl"
+          >
+            Start for free <ArrowRight className="h-4 w-4" />
+          </button>
+          <button
+            onClick={() => void handleCta("pro")}
+            className="flex h-12 items-center gap-2 rounded-2xl border border-white/40 px-8 text-sm font-semibold text-white transition hover:bg-white/10"
+          >
+            Try Pro free for 7 days
+          </button>
+        </div>
+      </section>
+
+      {/* Footer */}
+      <footer className="border-t border-[#e2e8f0] py-8 text-center text-xs text-[#94a3b8]">
+        © {new Date().getFullYear()} King CRM Hub. All rights reserved.
+      </footer>
+
+      {/* Toast */}
+      {toast && (
+        <div className="fixed bottom-6 left-1/2 z-50 -translate-x-1/2 rounded-2xl border border-[#e2e8f0] bg-white px-6 py-3.5 text-sm font-medium text-[#0f172a] shadow-xl">
+          {toast}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/pricing/crm-pricing-page.tsx
+++ b/src/components/pricing/crm-pricing-page.tsx
@@ -115,7 +115,7 @@ const COMPARE_FEATURES = [
   "Priority support",
 ];
 
-const FEATURE_MAP: Record<PlanId, (string | false)[]> = {
+const FEATURE_MAP: Record<PlanId, (string | boolean)[]> = {
   free:       ["1 seat", "50 leads", true, false, false, false, false, false, false, false],
   starter:    ["3 seats", "500 leads", true, true, "5 rules", false, false, false, false, false],
   pro:        ["10 seats", "Unlimited", true, true, "Unlimited", true, true, true, true, true],
@@ -169,7 +169,11 @@ export function CrmPricingPage() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ planId, interval }),
       });
-      const data = (await res.json()) as { url?: string | null; message?: string };
+      const data = (await res.json()) as { url?: string | null; message?: string; error?: string };
+      if (!res.ok) {
+        showToast(data.error ?? "Something went wrong. Please try again.");
+        return;
+      }
       if (data.url) {
         window.location.href = data.url;
       } else {

--- a/src/components/upgrade-banner.tsx
+++ b/src/components/upgrade-banner.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { Crown, X } from "lucide-react";
+
+export function CrmDashboardBanner() {
+  const [dismissed, setDismissed] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return sessionStorage.getItem("crm-dash-banner") === "1";
+  });
+
+  if (dismissed) return null;
+
+  return (
+    <div className="mb-6 overflow-hidden rounded-2xl border border-[#c9b98a] bg-[radial-gradient(ellipse_at_top_right,rgba(180,140,60,0.10),transparent_55%),linear-gradient(135deg,#fdfcf6,#f8f2e0)] shadow-sm">
+      <div className="flex items-center gap-4 px-5 py-4">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-[#b8860b] shadow">
+          <Crown className="h-5 w-5 text-white" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="font-semibold text-[#3a2a00]">Upgrade your plan</p>
+          <p className="mt-0.5 text-sm text-[#7a6020]">
+            Get AI-powered lead grading, automation, and unlimited pipelines. Starter from $39/mo.
+          </p>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <Link
+            href="/pricing"
+            className="rounded-xl bg-[#b8860b] px-4 py-2 text-sm font-bold text-white shadow transition-all hover:bg-[#9a6f09] hover:shadow-md"
+          >
+            View plans
+          </Link>
+          <button
+            onClick={() => {
+              sessionStorage.setItem("crm-dash-banner", "1");
+              setDismissed(true);
+            }}
+            className="rounded-lg p-1.5 text-[#9a8040] transition-colors hover:bg-white/60 hover:text-[#3a2a00]"
+            aria-label="Dismiss"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+      <div className="grid grid-cols-3 divide-x divide-[#d4b96a] border-t border-[#d4b96a]">
+        {[
+          { label: "Active leads", used: 12, limit: 25 },
+          { label: "AI grades / mo", used: 3, limit: 5 },
+          { label: "Automations", used: 1, limit: 2 },
+        ].map(({ label, used, limit }) => (
+          <div key={label} className="px-4 py-3">
+            <div className="mb-1.5 flex items-center justify-between">
+              <span className="text-xs text-[#7a6020]">{label}</span>
+              <span className="text-xs font-semibold text-[#3a2a00]">{used}/{limit}</span>
+            </div>
+            <div className="h-1.5 overflow-hidden rounded-full bg-[#d4b96a]/40">
+              <div
+                className="h-full rounded-full bg-gradient-to-r from-[#b8860b] to-[#d4a017] transition-all"
+                style={{ width: `${(used / limit) * 100}%` }}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/upgrade-banner.tsx
+++ b/src/components/upgrade-banner.tsx
@@ -4,10 +4,23 @@ import { useState } from "react";
 import Link from "next/link";
 import { Crown, X } from "lucide-react";
 
+function safeSessionStorage(key: string, value?: string): string | null {
+  try {
+    if (value !== undefined) {
+      sessionStorage.setItem(key, value);
+      return value;
+    }
+    return sessionStorage.getItem(key);
+  } catch {
+    // SecurityError in private/incognito mode — treat as if storage is empty
+    return null;
+  }
+}
+
 export function CrmDashboardBanner() {
   const [dismissed, setDismissed] = useState(() => {
     if (typeof window === "undefined") return false;
-    return sessionStorage.getItem("crm-dash-banner") === "1";
+    return safeSessionStorage("crm-dash-banner") === "1";
   });
 
   if (dismissed) return null;
@@ -33,7 +46,7 @@ export function CrmDashboardBanner() {
           </Link>
           <button
             onClick={() => {
-              sessionStorage.setItem("crm-dash-banner", "1");
+              safeSessionStorage("crm-dash-banner", "1");
               setDismissed(true);
             }}
             className="rounded-lg p-1.5 text-[#9a8040] transition-colors hover:bg-white/60 hover:text-[#3a2a00]"
@@ -57,7 +70,7 @@ export function CrmDashboardBanner() {
             <div className="h-1.5 overflow-hidden rounded-full bg-[#d4b96a]/40">
               <div
                 className="h-full rounded-full bg-gradient-to-r from-[#b8860b] to-[#d4a017] transition-all"
-                style={{ width: `${(used / limit) * 100}%` }}
+                style={{ width: `${Math.min(100, limit > 0 ? (used / limit) * 100 : 0)}%` }}
               />
             </div>
           </div>


### PR DESCRIPTION
## Summary

Commits all locally-built features from the VPS that were untracked in git.

### What's included
- **Pricing page** — 4-tier (Free / Starter / Pro / Enterprise) with monthly/yearly toggle
- **Onboarding wizard** — multi-step setup flow wired to org state
- **Upgrade banner** — dismissible banner showing usage vs plan limits
- **Billing checkout API route** — Stripe-ready stub (returns `url: null` with coming-soon message until Stripe is wired)
- **Onboarding state API route** — GET/PATCH org onboarding progress
- **Dockerfile** — for container builds
- **pricing-template.ts** — reference scaffold for Stripe product wiring
- **Prisma migration** — adds `onboardingCompleted`, `onboardingCompletedAt`, `onboardingStep` to Organization table
- **app/page.tsx** — updated with onboarding integration and workspace overlays

### ⚠️ Known stubs (intentional)
- Stripe price IDs are `price_crm_*_PLACEHOLDER` — wire after creating Stripe products
- Upgrade banner usage stats are hardcoded demo values — wire to real account data when billing is live

### Next steps after merge
- Run prisma migration on prod DB
- Create Stripe products and fill price IDs
- Rebuild Docker container

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a pricing page, multi-step onboarding wizard, upgrade banner, and API routes for checkout and onboarding state, plus a production `Dockerfile` and `Prisma` migration for onboarding. Also improves error handling, wizard resume, and container build performance.

- **Bug Fixes**
  - `Dockerfile`: use `npm ci`, set a non-secret `DATABASE_URL` build placeholder, honor `${PORT:-3003}`, and remove unused build tools from the builder stage to reduce build time and image size.
  - `pricing-template.ts`: `canUse()`/`getLimit()` now support the free tier via `FREE_PLAN`.
  - Billing checkout route: parse JSON in its own try/catch; return 400 for malformed input.
  - Onboarding API: `zod` `.refine()` rejects empty payloads; tighten the guard to only swallow true “column does not exist” migration errors and rethrow others.
  - Onboarding wizard: add `initialStep` and resume from persisted step; `useOnboarding` exposes `onboardingStep`.
  - Pricing page: fix `FEATURE_MAP` type to `(string|boolean)[]`; `handleCta` checks `res.ok` and surfaces 400/401 errors.
  - Upgrade banner: wrap `sessionStorage` access in try/catch; clamp progress bar width to prevent divide-by-zero.

- **Migration**
  - Run the `Prisma` migration on the target database.
  - Create `Stripe` products/prices and replace placeholder IDs in the checkout route and `pricing-template.ts`.
  - Enable real checkout by instantiating `Stripe` and setting `success_url`/`cancel_url`.
  - Replace demo usage in the upgrade banner with real org metrics.

<sup>Written for commit 0f2c9a0e75429fc5992399b2aad54c4be157443d. Summary will update on new commits. <a href="https://cubic.dev/pr/bradywhealth-lab/kingcrmhub/pull/106?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pricing page and client pricing component with monthly/yearly toggle, plan cards, comparison table, FAQ, testimonials, and checkout toast
  * Added pricing template with plan definitions, FREE plan, and helper functions (canUse/getLimit)
  * Added guided onboarding wizard with progress persistence, per-step backend actions, banner/CTA, and onboarding GET/PATCH API
  * Added billing checkout POST endpoint (returns guidance) and dashboard upgrade banner with dismissal and usage bars

* **Chores**
  * Introduced 3-stage Docker build and added onboarding DB migration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bradywhealth-lab/kingcrmhub/pull/106?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->